### PR TITLE
Add fundamental graph algorithms with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ endif()
 add_library(aurora_core STATIC
   src/core/graph.cpp
   src/core/storage.cpp
+  src/algo/bfs.cpp
+  src/algo/dfs.cpp
+  src/algo/dijkstra.cpp
 )
 
 target_include_directories(aurora_core
@@ -30,6 +33,12 @@ target_include_directories(aurora_core
 )
 
 target_compile_options(aurora_core PRIVATE -Wall -Wextra -Wpedantic)
+
+install(FILES
+  include/aurora/algo/bfs.hpp
+  include/aurora/algo/dfs.hpp
+  include/aurora/algo/dijkstra.hpp
+  DESTINATION include/aurora/algo)
 
 if(AURORA_BUILD_TESTS)
   enable_testing()

--- a/include/aurora/algo/bfs.hpp
+++ b/include/aurora/algo/bfs.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora {
+
+struct BfsResult {
+  std::unordered_map<NodeId, size_t> distance;
+  std::unordered_map<NodeId, NodeId> parent;
+};
+
+BfsResult bfs(const Graph& g, NodeId source);
+
+} // namespace aurora

--- a/include/aurora/algo/dfs.hpp
+++ b/include/aurora/algo/dfs.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora {
+
+struct DfsResult {
+  std::vector<NodeId> preorder;
+  std::unordered_map<NodeId, NodeId> parent;
+};
+
+DfsResult dfs(const Graph& g, NodeId source);
+
+} // namespace aurora

--- a/include/aurora/algo/dijkstra.hpp
+++ b/include/aurora/algo/dijkstra.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora {
+
+struct DijkstraResult {
+  std::unordered_map<NodeId, double> distance;
+  std::unordered_map<NodeId, NodeId> parent;
+};
+
+DijkstraResult dijkstra(const Graph& g, NodeId source,
+                        const std::string& weight_key = "weight",
+                        double default_weight = 1.0);
+
+} // namespace aurora

--- a/src/algo/bfs.cpp
+++ b/src/algo/bfs.cpp
@@ -1,0 +1,34 @@
+#include "aurora/algo/bfs.hpp"
+
+#include <queue>
+#include <unordered_set>
+
+namespace aurora {
+
+BfsResult bfs(const Graph& g, NodeId source) {
+  BfsResult res;
+  std::queue<NodeId> q;
+  std::unordered_set<NodeId> visited;
+
+  q.push(source);
+  visited.insert(source);
+  res.distance[source] = 0;
+  res.parent[source] = source;
+
+  while (!q.empty()) {
+    NodeId u = q.front();
+    q.pop();
+    size_t d = res.distance[u];
+    for (NodeId v : g.neighbors(u)) {
+      if (visited.insert(v).second) {
+        res.distance[v] = d + 1;
+        res.parent[v] = u;
+        q.push(v);
+      }
+    }
+  }
+
+  return res;
+}
+
+} // namespace aurora

--- a/src/algo/dfs.cpp
+++ b/src/algo/dfs.cpp
@@ -1,0 +1,25 @@
+#include "aurora/algo/dfs.hpp"
+
+#include <functional>
+#include <unordered_set>
+
+namespace aurora {
+
+DfsResult dfs(const Graph& g, NodeId source) {
+  DfsResult res;
+  std::unordered_set<NodeId> visited;
+  std::function<void(NodeId, NodeId)> visit = [&](NodeId u, NodeId p) {
+    visited.insert(u);
+    res.preorder.push_back(u);
+    res.parent[u] = p;
+    for (NodeId v : g.neighbors(u)) {
+      if (!visited.count(v)) {
+        visit(v, u);
+      }
+    }
+  };
+  visit(source, source);
+  return res;
+}
+
+} // namespace aurora

--- a/src/algo/dijkstra.cpp
+++ b/src/algo/dijkstra.cpp
@@ -1,0 +1,58 @@
+#include "aurora/algo/dijkstra.hpp"
+
+#include <queue>
+#include <stdexcept>
+
+#include "aurora/common/value.hpp"
+
+namespace aurora {
+
+struct PQItem {
+  double dist;
+  NodeId node;
+  bool operator>(const PQItem& other) const { return dist > other.dist; }
+};
+
+DijkstraResult dijkstra(const Graph& g, NodeId source,
+                        const std::string& weight_key,
+                        double default_weight) {
+  DijkstraResult res;
+  std::priority_queue<PQItem, std::vector<PQItem>, std::greater<>> pq;
+  res.distance[source] = 0.0;
+  res.parent[source] = source;
+  pq.push({0.0, source});
+
+  while (!pq.empty()) {
+    auto [dist_u, u] = pq.top();
+    pq.pop();
+    if (dist_u > res.distance[u]) continue;
+    for (EdgeId eid : g.out_edges(u)) {
+      const Edge* e = g.get_edge(eid);
+      if (!e) continue;
+      double w = default_weight;
+      auto it = e->props.find(weight_key);
+      if (it != e->props.end()) {
+        if (const Int* iv = as<Int>(it->second)) {
+          w = static_cast<double>(*iv);
+        } else if (const Real* rv = as<Real>(it->second)) {
+          w = *rv;
+        }
+      }
+      if (w < 0) {
+        throw std::runtime_error("Negative edge weight");
+      }
+      double nd = dist_u + w;
+      NodeId v = e->dst;
+      auto it_v = res.distance.find(v);
+      if (it_v == res.distance.end() || nd < it_v->second) {
+        res.distance[v] = nd;
+        res.parent[v] = u;
+        pq.push({nd, v});
+      }
+    }
+  }
+
+  return res;
+}
+
+} // namespace aurora

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,8 @@ FetchContent_MakeAvailable(googletest)
 add_executable(aurora_tests
   test_graph_basic.cpp
   test_storage_jsonl.cpp
+  test_algo_bfs_dfs.cpp
+  test_algo_dijkstra.cpp
 )
 
 target_link_libraries(aurora_tests PRIVATE aurora_core gtest_main)

--- a/tests/test_algo_bfs_dfs.cpp
+++ b/tests/test_algo_bfs_dfs.cpp
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include "aurora/core/graph.hpp"
+#include "aurora/algo/bfs.hpp"
+#include "aurora/algo/dfs.hpp"
+
+using namespace aurora;
+
+TEST(BFS, ConnectedGraph) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node(), n4=g.add_node(), n5=g.add_node();
+  g.add_edge(n1,n2);
+  g.add_edge(n1,n3);
+  g.add_edge(n2,n4);
+  g.add_edge(n3,n4);
+  g.add_edge(n4,n5);
+  auto res = bfs(g, n1);
+  EXPECT_EQ(res.distance.at(n1), 0u);
+  EXPECT_EQ(res.distance.at(n2), 1u);
+  EXPECT_EQ(res.distance.at(n3), 1u);
+  EXPECT_EQ(res.distance.at(n4), 2u);
+  EXPECT_EQ(res.distance.at(n5), 3u);
+  EXPECT_EQ(res.parent.at(n1), n1);
+  EXPECT_EQ(res.parent.at(n2), n1);
+  EXPECT_EQ(res.parent.at(n3), n1);
+  EXPECT_EQ(res.parent.at(n4), n2);
+  EXPECT_EQ(res.parent.at(n5), n4);
+}
+
+TEST(BFS, DisconnectedGraph) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node();
+  g.add_edge(n1,n2);
+  auto res = bfs(g, n1);
+  EXPECT_TRUE(res.distance.count(n1));
+  EXPECT_TRUE(res.distance.count(n2));
+  EXPECT_FALSE(res.distance.count(n3));
+}
+
+TEST(DFS, Chain) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node(), n4=g.add_node();
+  g.add_edge(n1,n2);
+  g.add_edge(n2,n3);
+  g.add_edge(n3,n4);
+  auto res = dfs(g, n1);
+  std::vector<NodeId> exp = {n1,n2,n3,n4};
+  EXPECT_EQ(res.preorder, exp);
+  EXPECT_EQ(res.parent.at(n1), n1);
+  EXPECT_EQ(res.parent.at(n2), n1);
+  EXPECT_EQ(res.parent.at(n3), n2);
+  EXPECT_EQ(res.parent.at(n4), n3);
+}
+
+TEST(DFS, Tree) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node(), n4=g.add_node(), n5=g.add_node();
+  g.add_edge(n1,n2);
+  g.add_edge(n1,n3);
+  g.add_edge(n2,n4);
+  g.add_edge(n2,n5);
+  auto res = dfs(g, n1);
+  std::vector<NodeId> exp = {n1,n2,n4,n5,n3};
+  EXPECT_EQ(res.preorder, exp);
+  EXPECT_EQ(res.parent.at(n1), n1);
+  EXPECT_EQ(res.parent.at(n2), n1);
+  EXPECT_EQ(res.parent.at(n4), n2);
+  EXPECT_EQ(res.parent.at(n5), n2);
+  EXPECT_EQ(res.parent.at(n3), n1);
+}
+
+TEST(DFS, Cycle) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node();
+  g.add_edge(n1,n2);
+  g.add_edge(n2,n3);
+  g.add_edge(n3,n1);
+  auto res = dfs(g, n1);
+  std::vector<NodeId> exp = {n1,n2,n3};
+  EXPECT_EQ(res.preorder, exp);
+  EXPECT_EQ(res.parent.at(n1), n1);
+  EXPECT_EQ(res.parent.at(n2), n1);
+  EXPECT_EQ(res.parent.at(n3), n2);
+}

--- a/tests/test_algo_dijkstra.cpp
+++ b/tests/test_algo_dijkstra.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include "aurora/core/graph.hpp"
+#include "aurora/algo/bfs.hpp"
+#include "aurora/algo/dijkstra.hpp"
+
+using namespace aurora;
+
+TEST(Dijkstra, WeightedGraph) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node(), n4=g.add_node();
+  g.add_edge(n1,n2,{},{{"weight", Real{1.0}}});
+  g.add_edge(n1,n3,{},{{"weight", Real{4.0}}});
+  g.add_edge(n2,n3,{},{{"weight", Real{2.0}}});
+  g.add_edge(n2,n4,{},{{"weight", Real{5.0}}});
+  g.add_edge(n3,n4,{},{{"weight", Real{1.0}}});
+  auto res=dijkstra(g,n1);
+  EXPECT_DOUBLE_EQ(res.distance.at(n1),0.0);
+  EXPECT_DOUBLE_EQ(res.distance.at(n2),1.0);
+  EXPECT_DOUBLE_EQ(res.distance.at(n3),3.0);
+  EXPECT_DOUBLE_EQ(res.distance.at(n4),4.0);
+  EXPECT_EQ(res.parent.at(n1), n1);
+  EXPECT_EQ(res.parent.at(n2), n1);
+  EXPECT_EQ(res.parent.at(n3), n2);
+  EXPECT_EQ(res.parent.at(n4), n3);
+}
+
+TEST(Dijkstra, DefaultWeight) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node();
+  g.add_edge(n1,n2);
+  auto res=dijkstra(g,n1,"weight",2.5);
+  EXPECT_DOUBLE_EQ(res.distance.at(n2),2.5);
+  EXPECT_EQ(res.parent.at(n2), n1);
+}
+
+TEST(Dijkstra, EqualWeightsMatchBfs) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node(), n3=g.add_node(), n4=g.add_node();
+  g.add_edge(n1,n2);
+  g.add_edge(n1,n3);
+  g.add_edge(n2,n4);
+  auto bfs_res = bfs(g, n1);
+  auto dij_res = dijkstra(g, n1);
+  for (auto [node, dist] : bfs_res.distance) {
+    ASSERT_TRUE(dij_res.distance.count(node));
+    EXPECT_DOUBLE_EQ(dij_res.distance[node], static_cast<double>(dist));
+  }
+}
+
+TEST(Dijkstra, NegativeWeightThrows) {
+  Graph g;
+  NodeId n1=g.add_node(), n2=g.add_node();
+  g.add_edge(n1,n2,{},{{"weight", Real{-1.0}}});
+  EXPECT_THROW(dijkstra(g,n1), std::runtime_error);
+}


### PR DESCRIPTION
## Summary
- Implement BFS, DFS, and Dijkstra single-source shortest path algorithms
- Integrate algorithm sources and headers into build system
- Add comprehensive unit tests for graph algorithms

## Testing
- `./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5ee7ef8688321a4c662e1090bd4d4