### PR TITLE
Add AGQL lexer, parser, executor, and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(aurora_core STATIC
   src/algo/bfs.cpp
   src/algo/dfs.cpp
   src/algo/dijkstra.cpp
+  src/agql/lexer.cpp
+  src/agql/parser.cpp
+  src/agql/exec.cpp
 )
 
 target_include_directories(aurora_core
@@ -39,6 +42,15 @@ install(FILES
   include/aurora/algo/dfs.hpp
   include/aurora/algo/dijkstra.hpp
   DESTINATION include/aurora/algo)
+
+install(FILES
+  include/aurora/agql/token.hpp
+  include/aurora/agql/lexer.hpp
+  include/aurora/agql/ast.hpp
+  include/aurora/agql/parser.hpp
+  include/aurora/agql/exec.hpp
+  include/aurora/agql/errors.hpp
+  DESTINATION include/aurora/agql)
 
 if(AURORA_BUILD_TESTS)
   enable_testing()

--- a/include/aurora/agql/ast.hpp
+++ b/include/aurora/agql/ast.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace aurora::agql {
+
+struct Null {};
+using Scalar = std::variant<Null, int64_t, double, bool, std::string>;
+
+struct Expr; // forward
+using ExprPtr = std::unique_ptr<Expr>;
+
+// Expressions
+struct ExprIdent { std::string name; };
+struct ExprProp  { std::string var; std::string key; };
+struct ExprLabelIs { std::string var; std::string label; };
+struct ExprLiteral { Scalar value; };
+
+enum class CmpOp { Eq, Ne, Lt, Le, Gt, Ge };
+struct ExprCmp { ExprPtr lhs; CmpOp op; ExprPtr rhs; };
+struct ExprNot { ExprPtr e; };
+struct ExprAnd { ExprPtr lhs, rhs; };
+struct ExprOr  { ExprPtr lhs, rhs; };
+
+struct Expr : std::variant<ExprIdent, ExprProp, ExprLabelIs, ExprLiteral,
+                           ExprCmp, ExprNot, ExprAnd, ExprOr> {
+  using std::variant<ExprIdent, ExprProp, ExprLabelIs, ExprLiteral,
+                     ExprCmp, ExprNot, ExprAnd, ExprOr>::variant;
+};
+
+// Node/edge patterns
+struct PropPair { std::string key; Scalar value; };
+struct PropMap { std::vector<PropPair> items; };
+
+struct NodePattern {
+  std::optional<std::string> var;
+  std::optional<std::string> label;
+  std::optional<PropMap> props;
+};
+
+struct RelPattern {
+  std::optional<std::string> label;
+  std::optional<PropMap> props;
+};
+
+struct Pattern {
+  NodePattern left;
+  std::optional<RelPattern> rel;
+  std::optional<NodePattern> right;
+};
+
+// Statements
+struct StmtCreateNode { NodePattern node; };
+struct StmtCreateEdge { NodePattern left; RelPattern rel; NodePattern right; };
+
+struct ReturnItem {
+  Expr expr;
+  std::optional<std::string> alias;
+};
+struct StmtMatch {
+  Pattern pattern;
+  std::optional<Expr> where;
+  std::vector<ReturnItem> ret;
+};
+
+using Stmt = std::variant<StmtCreateNode, StmtCreateEdge, StmtMatch>;
+
+struct Script { std::vector<Stmt> stmts; };
+
+} // namespace aurora::agql
+

--- a/include/aurora/agql/errors.hpp
+++ b/include/aurora/agql/errors.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace aurora::agql {
+
+struct Error : std::runtime_error {
+  size_t line;
+  size_t col;
+  Error(const std::string& msg, size_t l, size_t c)
+      : std::runtime_error(msg), line(l), col(c) {}
+};
+
+struct LexError : Error {
+  LexError(const std::string& msg, size_t l, size_t c) : Error(msg, l, c) {}
+};
+
+struct ParseError : Error {
+  ParseError(const std::string& msg, size_t l, size_t c) : Error(msg, l, c) {}
+};
+
+} // namespace aurora::agql
+

--- a/include/aurora/agql/exec.hpp
+++ b/include/aurora/agql/exec.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "aurora/agql/ast.hpp"
+#include "aurora/core/graph.hpp"
+
+namespace aurora::agql {
+
+struct RowValue {
+  using Scalar = std::variant<std::monostate, int64_t, double, bool, std::string, NodeId>;
+  std::vector<std::pair<std::string, Scalar>> columns;
+};
+
+struct QueryResult {
+  std::vector<RowValue> rows;
+  size_t nodes_created = 0;
+  size_t edges_created = 0;
+};
+
+class Executor {
+public:
+  explicit Executor(Graph& g);
+
+  QueryResult run(const Script& script);
+
+private:
+  Graph& g_;
+};
+
+} // namespace aurora::agql
+

--- a/include/aurora/agql/lexer.hpp
+++ b/include/aurora/agql/lexer.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "aurora/agql/errors.hpp"
+#include "aurora/agql/token.hpp"
+
+namespace aurora::agql {
+
+std::vector<Token> lex(std::string_view input);
+
+} // namespace aurora::agql
+

--- a/include/aurora/agql/parser.hpp
+++ b/include/aurora/agql/parser.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string_view>
+
+#include "aurora/agql/ast.hpp"
+#include "aurora/agql/errors.hpp"
+#include "aurora/agql/token.hpp"
+
+namespace aurora::agql {
+
+Script parse_script(std::string_view input);
+
+} // namespace aurora::agql
+

--- a/include/aurora/agql/token.hpp
+++ b/include/aurora/agql/token.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+namespace aurora::agql {
+
+enum class TokenKind {
+  End,
+  // keywords
+  Create, Match, Where, Return, And, Or, Not, As,
+  // symbols
+  LParen, RParen, LBrace, RBrace, LBracket, RBracket,
+  Colon, Comma, Dot, Semicolon,
+  Arrow, Minus,
+  Equal, NotEqual, Less, LessEq, Greater, GreaterEq,
+  // literals
+  String, Int, Real, True, False, Null,
+  Ident
+};
+
+struct Token {
+  TokenKind kind;
+  std::string lexeme;
+  size_t line;
+  size_t col;
+};
+
+} // namespace aurora::agql
+

--- a/src/agql/exec.cpp
+++ b/src/agql/exec.cpp
@@ -1,0 +1,244 @@
+#include "aurora/agql/exec.hpp"
+
+#include <unordered_map>
+#include <algorithm>
+
+#include "aurora/common/value.hpp"
+
+namespace aurora::agql {
+
+namespace {
+using Binding = std::unordered_map<std::string, NodeId>;
+
+Value to_value(const Scalar& s) {
+  return std::visit([](auto&& v)->Value{
+    using T=std::decay_t<decltype(v)>; if constexpr(std::is_same_v<T,Null>) return std::monostate{}; else return v; }, s);
+}
+
+Scalar from_value(const Value& v) {
+  return std::visit([](auto&& val)->Scalar{
+    using T=std::decay_t<decltype(val)>; if constexpr(std::is_same_v<T,std::monostate>) return Null{}; else return Scalar(val); }, v);
+}
+
+Properties to_properties(const std::optional<PropMap>& pm) {
+  Properties p;
+  if(!pm) return p;
+  for(const auto& pair: pm->items) p[pair.key] = to_value(pair.value);
+  return p;
+}
+
+bool node_has_label(const Node& n, const std::string& label){
+  return std::find(n.labels.begin(), n.labels.end(), label)!=n.labels.end();
+}
+
+bool value_eq(const Value& v, const Scalar& s){
+  Scalar sv = from_value(v);
+  if(sv.index()!=s.index()) return false;
+  if(std::holds_alternative<Null>(s)) return true; // both null
+  if(std::holds_alternative<int64_t>(s)) return std::get<int64_t>(sv)==std::get<int64_t>(s);
+  if(std::holds_alternative<double>(s)) return std::get<double>(sv)==std::get<double>(s);
+  if(std::holds_alternative<bool>(s)) return std::get<bool>(sv)==std::get<bool>(s);
+  if(std::holds_alternative<std::string>(s)) return std::get<std::string>(sv)==std::get<std::string>(s);
+  return false;
+}
+
+bool match_node_props(const Node& n, const PropMap& pm){
+  for(const auto& pp : pm.items){
+    auto it = n.props.find(pp.key);
+    if(it==n.props.end()) return false;
+    if(!value_eq(it->second, pp.value)) return false;
+  }
+  return true;
+}
+
+bool match_edge_props(const Edge& e, const PropMap& pm){
+  for(const auto& pp : pm.items){
+    auto it = e.props.find(pp.key);
+    if(it==e.props.end()) return false;
+    if(!value_eq(it->second, pp.value)) return false;
+  }
+  return true;
+}
+
+Scalar get_prop_scalar(Graph& g, NodeId id, const std::string& key){
+  const Node* n = g.get_node(id);
+  if(!n) return Null{};
+  auto it = n->props.find(key);
+  if(it==n->props.end()) return Null{};
+  return from_value(it->second);
+}
+
+bool node_has_label(Graph& g, NodeId id, const std::string& label){
+  const Node* n = g.get_node(id);
+  return n && node_has_label(*n,label);
+}
+
+bool compare_scalar(const Scalar& a, CmpOp op, const Scalar& b){
+  if(std::holds_alternative<Null>(a) || std::holds_alternative<Null>(b))
+    return op==CmpOp::Eq && std::holds_alternative<Null>(a) && std::holds_alternative<Null>(b);
+  if(a.index()!=b.index()) return false;
+  if(std::holds_alternative<int64_t>(a)){
+    auto av=std::get<int64_t>(a), bv=std::get<int64_t>(b);
+    switch(op){case CmpOp::Eq:return av==bv;case CmpOp::Ne:return av!=bv;case CmpOp::Lt:return av<bv;case CmpOp::Le:return av<=bv;case CmpOp::Gt:return av>bv;case CmpOp::Ge:return av>=bv;}
+  } else if(std::holds_alternative<double>(a)){
+    auto av=std::get<double>(a), bv=std::get<double>(b);
+    switch(op){case CmpOp::Eq:return av==bv;case CmpOp::Ne:return av!=bv;case CmpOp::Lt:return av<bv;case CmpOp::Le:return av<=bv;case CmpOp::Gt:return av>bv;case CmpOp::Ge:return av>=bv;}
+  } else if(std::holds_alternative<bool>(a)){
+    auto av=std::get<bool>(a), bv=std::get<bool>(b);
+    switch(op){case CmpOp::Eq:return av==bv;case CmpOp::Ne:return av!=bv;default:return false;}
+  } else if(std::holds_alternative<std::string>(a)){
+    auto av=std::get<std::string>(a), bv=std::get<std::string>(b);
+    switch(op){case CmpOp::Eq:return av==bv;case CmpOp::Ne:return av!=bv;case CmpOp::Lt:return av<bv;case CmpOp::Le:return av<=bv;case CmpOp::Gt:return av>bv;case CmpOp::Ge:return av>=bv;}
+  }
+  return false;
+}
+
+bool is_truthy(const Scalar& s){
+  if(std::holds_alternative<Null>(s)) return false;
+  if(std::holds_alternative<bool>(s)) return std::get<bool>(s);
+  if(std::holds_alternative<int64_t>(s)) return std::get<int64_t>(s)!=0;
+  if(std::holds_alternative<double>(s)) return std::get<double>(s)!=0.0;
+  if(std::holds_alternative<std::string>(s)) return !std::get<std::string>(s).empty();
+  return false;
+}
+
+Scalar eval_simple(Graph& g, const Expr& e, const Binding& b){
+  return std::visit([&](auto&& node)->Scalar{
+    using T = std::decay_t<decltype(node)>;
+    if constexpr(std::is_same_v<T,ExprIdent>){
+      auto it = b.find(node.name); if(it==b.end()) return Null{}; return static_cast<int64_t>(it->second); // but NodeId may exceed int64? NodeId is uint64, but variant uses NodeId later; for comparisons treat as int64 not needed. For simple, but for projection we handle separately.
+    } else if constexpr(std::is_same_v<T,ExprProp>){
+      auto it = b.find(node.var); if(it==b.end()) return Null{}; return get_prop_scalar(g, it->second, node.key);
+    } else if constexpr(std::is_same_v<T,ExprLiteral>){
+      return node.value;
+    } else if constexpr(std::is_same_v<T,ExprLabelIs>){
+      auto it = b.find(node.var); if(it==b.end()) return false; return node_has_label(g, it->second, node.label);
+    } else if constexpr(std::is_same_v<T,ExprCmp>){
+      Scalar l = eval_simple(g, *node.lhs, b); Scalar r = eval_simple(g, *node.rhs, b); return compare_scalar(l,node.op,r);
+    } else if constexpr(std::is_same_v<T,ExprNot>){
+      return !is_truthy(eval_simple(g,*node.e,b));
+    } else if constexpr(std::is_same_v<T,ExprAnd>){
+      return is_truthy(eval_simple(g,*node.lhs,b)) && is_truthy(eval_simple(g,*node.rhs,b));
+    } else if constexpr(std::is_same_v<T,ExprOr>){
+      return is_truthy(eval_simple(g,*node.lhs,b)) || is_truthy(eval_simple(g,*node.rhs,b));
+    } else {
+      return Null{};
+    }
+  }, e);
+}
+
+bool eval_bool(Graph& g, const Expr& e, const Binding& b){
+  Scalar s = eval_simple(g, e, b);
+  if(std::holds_alternative<bool>(s)) return std::get<bool>(s);
+  return is_truthy(s);
+}
+
+RowValue::Scalar project_expr(Graph& g, const Expr& e, const Binding& b){
+  return std::visit([&](auto&& node)->RowValue::Scalar{
+    using T=std::decay_t<decltype(node)>;
+    if constexpr(std::is_same_v<T,ExprIdent>){
+      auto it = b.find(node.name); if(it==b.end()) return RowValue::Scalar{}; return it->second;
+    } else if constexpr(std::is_same_v<T,ExprProp>){
+      auto it = b.find(node.var); if(it==b.end()) return RowValue::Scalar{}; Scalar s = get_prop_scalar(g,it->second,node.key); return std::visit([](auto&& v)->RowValue::Scalar{ using U=std::decay_t<decltype(v)>; if constexpr(std::is_same_v<U,Null>) return std::monostate{}; else return v; }, s);
+    } else if constexpr(std::is_same_v<T,ExprLiteral>){
+      return std::visit([](auto&& v)->RowValue::Scalar{ using U=std::decay_t<decltype(v)>; if constexpr(std::is_same_v<U,Null>) return std::monostate{}; else return v; }, node.value);
+    } else {
+      return RowValue::Scalar{};
+    }
+  }, e);
+}
+
+std::string default_column_name(const Expr& e){
+  return std::visit([](auto&& node)->std::string{
+    using T=std::decay_t<decltype(node)>;
+    if constexpr(std::is_same_v<T,ExprIdent>) return node.name;
+    else if constexpr(std::is_same_v<T,ExprProp>) return node.var+"."+node.key;
+    else return std::string{};
+  }, e);
+}
+
+std::vector<NodeId> match_node_pattern(Graph& g, const NodePattern& np){
+  std::vector<NodeId> res;
+  for(NodeId id=1; id<=g.node_count(); ++id){
+    const Node* n = g.get_node(id); if(!n) continue;
+    if(np.label && !node_has_label(*n,*np.label)) continue;
+    if(np.props && !match_node_props(*n,*np.props)) continue;
+    res.push_back(id);
+  }
+  return res;
+}
+
+bool match_node(Graph& g, NodeId id, const NodePattern& np){
+  const Node* n = g.get_node(id); if(!n) return false;
+  if(np.label && !node_has_label(*n,*np.label)) return false;
+  if(np.props && !match_node_props(*n,*np.props)) return false;
+  return true;
+}
+
+std::vector<Binding> match_pattern(Graph& g, const Pattern& pat){
+  std::vector<Binding> binds;
+  auto left_nodes = match_node_pattern(g, pat.left);
+  if(!pat.rel){
+    for(NodeId id : left_nodes){
+      Binding b; if(pat.left.var) b[*pat.left.var]=id; binds.push_back(std::move(b));
+    }
+  } else {
+    for(NodeId src : left_nodes){
+      for(EdgeId eid : g.out_edges(src)){
+        const Edge* e = g.get_edge(eid); if(!e) continue;
+        if(pat.rel->label && std::find(e->labels.begin(), e->labels.end(), *pat.rel->label)==e->labels.end()) continue;
+        if(pat.rel->props && !match_edge_props(*e, *pat.rel->props)) continue;
+        NodeId dst = e->dst;
+        if(pat.right && !match_node(g,dst,*pat.right)) continue;
+        Binding b; if(pat.left.var) b[*pat.left.var]=src; if(pat.right && pat.right->var) b[*pat.right->var]=dst; binds.push_back(std::move(b));
+      }
+    }
+  }
+  return binds;
+}
+
+} // namespace
+
+Executor::Executor(Graph& g) : g_(g) {}
+
+QueryResult Executor::run(const Script& script){
+  QueryResult res;
+  for(const Stmt& st : script.stmts){
+    std::visit([&](auto&& s){
+      using T=std::decay_t<decltype(s)>;
+      if constexpr(std::is_same_v<T,StmtCreateNode>){
+        Properties props = to_properties(s.node.props);
+        std::vector<std::string> labels; if(s.node.label) labels.push_back(*s.node.label);
+        g_.add_node(std::move(labels), std::move(props));
+        res.nodes_created++;
+      } else if constexpr(std::is_same_v<T,StmtCreateEdge>){
+        auto find_or_create = [&](const NodePattern& np){
+          int64_t idval = 0; if(!np.props) throw std::runtime_error("id required");
+          bool foundid=false; Properties p = to_properties(np.props);
+          auto itid = p.find("id"); if(itid!=p.end()) { if(auto pi = as<Int>(itid->second)) { idval=*pi; foundid=true; } }
+          if(!foundid) throw std::runtime_error("id required");
+          for(NodeId nid=1; nid<=g_.node_count(); ++nid){
+            const Node* n = g_.get_node(nid); if(!n) continue; auto it=n->props.find("id"); if(it!=n->props.end()) { if(auto pi=as<Int>(it->second); pi && *pi==idval) return nid; } }
+          std::vector<std::string> labels; if(np.label) labels.push_back(*np.label);
+          return g_.add_node(std::move(labels), std::move(p));
+        };
+        NodeId src = find_or_create(s.left);
+        NodeId dst = find_or_create(s.right);
+        std::vector<std::string> labels; if(s.rel.label) labels.push_back(*s.rel.label);
+        Properties props = to_properties(s.rel.props);
+        g_.add_edge(src,dst,std::move(labels),std::move(props));
+        res.edges_created++;
+      } else if constexpr(std::is_same_v<T,StmtMatch>){
+        auto bindings = match_pattern(g_, s.pattern);
+        std::vector<Binding> filtered;
+        for(auto& b : bindings){ if(!s.where || eval_bool(g_, *s.where, b)) filtered.push_back(b); }
+        for(auto& b : filtered){
+          RowValue row; for(const auto& item : s.ret){ RowValue::Scalar val = project_expr(g_, item.expr, b); std::string name = item.alias?*item.alias:default_column_name(item.expr); row.columns.emplace_back(std::move(name), std::move(val)); } res.rows.push_back(std::move(row)); }
+      }
+    }, st);
+  }
+  return res;
+}
+
+} // namespace aurora::agql
+

--- a/src/agql/lexer.cpp
+++ b/src/agql/lexer.cpp
@@ -1,0 +1,170 @@
+#include "aurora/agql/lexer.hpp"
+
+#include <cctype>
+#include <charconv>
+
+namespace aurora::agql {
+
+namespace {
+struct Lexer {
+  std::string_view input;
+  size_t pos = 0;
+  size_t line = 1;
+  size_t col = 1;
+  std::vector<Token> toks;
+
+  char peek() const { return pos < input.size() ? input[pos] : '\0'; }
+  char get() {
+    char c = peek();
+    if (c == '\n') {
+      line++; col = 1;
+    } else if (c != '\0') {
+      col++;
+    }
+    pos++;
+    return c;
+  }
+
+  void add(TokenKind k, std::string lex, size_t l, size_t c) {
+    toks.push_back(Token{k, std::move(lex), l, c});
+  }
+
+  [[noreturn]] void error(const std::string& msg) { throw LexError(msg, line, col); }
+
+  void skip_ws() {
+    while (true) {
+      char c = peek();
+      if (c == '\0') return;
+      if (c == ' ' || c == '\t' || c == '\r' || c == '\n') { get(); continue; }
+      if (c == '-' && pos + 1 < input.size() && input[pos+1] == '-') {
+        while (peek() && peek() != '\n') get();
+        continue;
+      }
+      return;
+    }
+  }
+
+  void lex_number() {
+    size_t start_pos = pos; size_t l=line, c=col;
+    bool is_real = false;
+    if (peek()=='-') get();
+    while (std::isdigit(peek())) get();
+    if (peek()=='.') {
+      is_real=true; get();
+      if (!std::isdigit(peek())) error("Invalid real literal");
+      while (std::isdigit(peek())) get();
+      if (peek()=='e' || peek()=='E') {
+        get();
+        if (peek()=='+'||peek()=='-') get();
+        if (!std::isdigit(peek())) error("Invalid real literal");
+        while (std::isdigit(peek())) get();
+      }
+    }
+    std::string lex(input.substr(start_pos, pos-start_pos));
+    if (is_real) {
+      double val; auto [p, ec] = std::from_chars(lex.data(), lex.data()+lex.size(), val);
+      if (ec != std::errc{}) error("Invalid real literal");
+      add(TokenKind::Real, lex, l, c);
+    } else {
+      long long val; auto [p, ec] = std::from_chars(lex.data(), lex.data()+lex.size(), val);
+      if (ec != std::errc{}) error("Invalid int literal");
+      add(TokenKind::Int, lex, l, c);
+    }
+  }
+
+  void lex_string() {
+    size_t l=line, c=col; get();
+    std::string out;
+    while (true) {
+      char ch = peek();
+      if (ch=='\0' || ch=='\n') error("Unterminated string");
+      if (ch=='"') { get(); break; }
+      if (ch=='\\') {
+        get(); char esc = peek();
+        if (esc=='"' || esc=='\\') { out.push_back(esc); get(); }
+        else error("Invalid escape");
+      } else {
+        out.push_back(ch); get();
+      }
+    }
+    add(TokenKind::String, out, l, c);
+  }
+
+  void lex_ident() {
+    size_t start=pos; size_t l=line, c=col;
+    while (std::isalnum(peek()) || peek()=='_') get();
+    std::string lexeme(input.substr(start, pos-start));
+    std::string upper; upper.reserve(lexeme.size());
+    for(char ch:lexeme) upper.push_back(std::toupper(static_cast<unsigned char>(ch)));
+    if (upper=="CREATE") add(TokenKind::Create, lexeme, l, c);
+    else if (upper=="MATCH") add(TokenKind::Match, lexeme, l, c);
+    else if (upper=="WHERE") add(TokenKind::Where, lexeme, l, c);
+    else if (upper=="RETURN") add(TokenKind::Return, lexeme, l, c);
+    else if (upper=="AND") add(TokenKind::And, lexeme, l, c);
+    else if (upper=="OR") add(TokenKind::Or, lexeme, l, c);
+    else if (upper=="NOT") add(TokenKind::Not, lexeme, l, c);
+    else if (upper=="AS") add(TokenKind::As, lexeme, l, c);
+    else if (upper=="TRUE") add(TokenKind::True, lexeme, l, c);
+    else if (upper=="FALSE") add(TokenKind::False, lexeme, l, c);
+    else if (upper=="NULL") add(TokenKind::Null, lexeme, l, c);
+    else add(TokenKind::Ident, lexeme, l, c);
+  }
+
+  void run() {
+    while (true) {
+      skip_ws();
+      size_t l=line, c=col;
+      char ch = peek();
+      if (ch=='\0') break;
+      if (std::isalpha(ch) || ch=='_') { lex_ident(); continue; }
+      if (std::isdigit(ch) || (ch=='-' && pos+1 < input.size() && std::isdigit(input[pos+1]))) {
+        lex_number(); continue; }
+      switch (ch) {
+        case '(' : get(); add(TokenKind::LParen, "(", l, c); break;
+        case ')' : get(); add(TokenKind::RParen, ")", l, c); break;
+        case '{' : get(); add(TokenKind::LBrace, "{", l, c); break;
+        case '}' : get(); add(TokenKind::RBrace, "}", l, c); break;
+        case '[' : get(); add(TokenKind::LBracket, "[", l, c); break;
+        case ']' : get(); add(TokenKind::RBracket, "]", l, c); break;
+        case ':' : get(); add(TokenKind::Colon, ":", l, c); break;
+        case ',' : get(); add(TokenKind::Comma, ",", l, c); break;
+        case '.' : get(); add(TokenKind::Dot, ".", l, c); break;
+        case ';' : get(); add(TokenKind::Semicolon, ";", l, c); break;
+        case '"': lex_string(); break;
+        case '-' : {
+          get();
+          if (peek()=='>') { get(); add(TokenKind::Arrow, "->", l, c); }
+          else add(TokenKind::Minus, "-", l, c);
+          break;
+        }
+        case '=': get(); add(TokenKind::Equal, "=", l, c); break;
+        case '!': {
+          get(); if (peek()=='=') { get(); add(TokenKind::NotEqual, "!=", l, c); }
+          else error("Unexpected '!'");
+          break;
+        }
+        case '<': {
+          get(); if (peek()=='=') { get(); add(TokenKind::LessEq, "<=", l, c); }
+          else add(TokenKind::Less, "<", l, c); break;
+        }
+        case '>': {
+          get(); if (peek()=='=') { get(); add(TokenKind::GreaterEq, ">=", l, c); }
+          else add(TokenKind::Greater, ">", l, c); break;
+        }
+        default:
+          error(std::string("Unexpected character: ")+ch);
+      }
+    }
+    add(TokenKind::End, "", line, col);
+  }
+};
+} // namespace
+
+std::vector<Token> lex(std::string_view input) {
+  Lexer L{input};
+  L.run();
+  return L.toks;
+}
+
+} // namespace aurora::agql
+

--- a/src/agql/parser.cpp
+++ b/src/agql/parser.cpp
@@ -1,0 +1,190 @@
+#include "aurora/agql/parser.hpp"
+#include "aurora/agql/lexer.hpp"
+
+#include <cctype>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace aurora::agql {
+
+namespace {
+struct Parser {
+  std::vector<Token> toks;
+  size_t i=0;
+
+  explicit Parser(std::vector<Token> t) : toks(std::move(t)) {}
+
+  const Token& peek() const { return toks[i]; }
+  const Token& prev() const { return toks[i-1]; }
+  bool check(TokenKind k) const { return peek().kind==k; }
+  bool match(TokenKind k){ if(check(k)){ ++i; return true;} return false; }
+  Token expect(TokenKind k, const char* msg){ if(!check(k)) error(msg); return toks[i++]; }
+  [[noreturn]] void error(const std::string& msg) const { throw ParseError(msg, peek().line, peek().col); }
+
+  Script parse_script() {
+    Script s;
+    while(!check(TokenKind::End)){
+      s.stmts.push_back(parse_stmt());
+      match(TokenKind::Semicolon);
+    }
+    return s;
+  }
+
+  Stmt parse_stmt(){
+    if(match(TokenKind::Create)){
+      NodePattern left = parse_node_pattern();
+      if(match(TokenKind::Minus)){
+        expect(TokenKind::LBracket, "[");
+        RelPattern rel = parse_rel_body();
+        expect(TokenKind::RBracket, "]");
+        expect(TokenKind::Arrow, "->");
+        NodePattern right = parse_node_pattern();
+        return StmtCreateEdge{left, rel, right};
+      }else{
+        return StmtCreateNode{left};
+      }
+    } else if(match(TokenKind::Match)) {
+      Pattern pat = parse_pattern();
+      std::optional<Expr> where;
+      if(match(TokenKind::Where)) where = parse_expr();
+      expect(TokenKind::Return, "RETURN");
+      std::vector<ReturnItem> items;
+      items.push_back(parse_return_item());
+      while(match(TokenKind::Comma)) items.push_back(parse_return_item());
+      // validate variable usage
+      std::unordered_set<std::string> allowed;
+      if(pat.left.var) allowed.insert(*pat.left.var);
+      if(pat.right && pat.right->var) allowed.insert(*pat.right->var);
+      auto check_vars=[&](const Expr& e){
+        std::unordered_set<std::string> used;
+        collect_vars(e, used);
+        for(const auto& v:used) if(!allowed.count(v)) error("Unknown variable in expression");
+      };
+      if(where) check_vars(*where);
+      for(const auto& it:items) check_vars(it.expr);
+      return StmtMatch{pat, std::move(where), std::move(items)};
+    }
+    error("Unknown statement");
+  }
+
+  Pattern parse_pattern(){
+    NodePattern left = parse_node_pattern();
+    if(match(TokenKind::Minus)){
+      expect(TokenKind::LBracket, "[");
+      RelPattern rel = parse_rel_body();
+      expect(TokenKind::RBracket, "]");
+      expect(TokenKind::Arrow, "->");
+      NodePattern right = parse_node_pattern();
+      return Pattern{left, rel, right};
+    }
+    return Pattern{left, std::nullopt, std::nullopt};
+  }
+
+  RelPattern parse_rel_body(){
+    RelPattern r;
+    if(match(TokenKind::Colon)) r.label = expect(TokenKind::Ident, "relationship type").lexeme;
+    if(match(TokenKind::LBrace)){
+      r.props = PropMap{};
+      if(!check(TokenKind::RBrace)){
+        r.props->items.push_back(parse_prop_pair());
+        while(match(TokenKind::Comma)) r.props->items.push_back(parse_prop_pair());
+      }
+      expect(TokenKind::RBrace, "}");
+    }
+    return r;
+  }
+
+  NodePattern parse_node_pattern(){
+    expect(TokenKind::LParen, "(");
+    NodePattern n;
+    if(check(TokenKind::Ident)){ n.var = peek().lexeme; i++; }
+    if(match(TokenKind::Colon)) n.label = expect(TokenKind::Ident, "label").lexeme;
+    if(match(TokenKind::LBrace)){
+      n.props = PropMap{};
+      if(!check(TokenKind::RBrace)){
+        n.props->items.push_back(parse_prop_pair());
+        while(match(TokenKind::Comma)) n.props->items.push_back(parse_prop_pair());
+      }
+      expect(TokenKind::RBrace, "}");
+    }
+    expect(TokenKind::RParen, ")");
+    return n;
+  }
+
+  PropPair parse_prop_pair(){
+    std::string key = expect(TokenKind::Ident, "prop key").lexeme;
+    expect(TokenKind::Colon, ":");
+    Scalar val = parse_literal();
+    return PropPair{key, val};
+  }
+
+  Scalar parse_literal(){
+    if(match(TokenKind::Null)) return Null{};
+    if(match(TokenKind::True)) return true;
+    if(match(TokenKind::False)) return false;
+    if(match(TokenKind::Int)) return std::stoll(prev().lexeme);
+    if(match(TokenKind::Real)) return std::stod(prev().lexeme);
+    if(match(TokenKind::String)) return prev().lexeme;
+    error("Expected literal");
+  }
+
+  ReturnItem parse_return_item(){
+    Expr e = parse_expr();
+    std::optional<std::string> alias;
+    if(match(TokenKind::As)) alias = expect(TokenKind::Ident, "alias").lexeme;
+    return ReturnItem{std::move(e), std::move(alias)};
+  }
+
+  // Expression parsing
+  Expr parse_expr(){ return parse_or(); }
+  Expr parse_or(){ Expr left = parse_and(); while(match(TokenKind::Or)){ Expr rhs = parse_and(); auto l=std::make_unique<Expr>(std::move(left)); auto r=std::make_unique<Expr>(std::move(rhs)); left = ExprOr{std::move(l), std::move(r)}; } return left; }
+  Expr parse_and(){ Expr left = parse_not(); while(match(TokenKind::And)){ Expr rhs = parse_not(); auto l=std::make_unique<Expr>(std::move(left)); auto r=std::make_unique<Expr>(std::move(rhs)); left = ExprAnd{std::move(l), std::move(r)}; } return left; }
+  Expr parse_not(){ if(match(TokenKind::Not)){ Expr e = parse_not(); auto ptr=std::make_unique<Expr>(std::move(e)); return ExprNot{std::move(ptr)}; } return parse_cmp(); }
+  Expr parse_cmp(){ Expr left = parse_primary(); if(match(TokenKind::Equal)||match(TokenKind::NotEqual)||match(TokenKind::Less)||match(TokenKind::LessEq)||match(TokenKind::Greater)||match(TokenKind::GreaterEq)){ Token opTok = prev(); CmpOp op; switch(opTok.kind){ case TokenKind::Equal: op=CmpOp::Eq; break; case TokenKind::NotEqual: op=CmpOp::Ne; break; case TokenKind::Less: op=CmpOp::Lt; break; case TokenKind::LessEq: op=CmpOp::Le; break; case TokenKind::Greater: op=CmpOp::Gt; break; case TokenKind::GreaterEq: op=CmpOp::Ge; break; default: op=CmpOp::Eq; }
+    Expr right = parse_primary(); auto l=std::make_unique<Expr>(std::move(left)); auto r=std::make_unique<Expr>(std::move(right)); return ExprCmp{std::move(l), op, std::move(r)}; } return left; }
+
+  Expr parse_primary(){
+    if(match(TokenKind::LParen)){ Expr e = parse_expr(); expect(TokenKind::RParen, ")"); return e; }
+    if(match(TokenKind::Null)) return ExprLiteral{Null{}};
+    if(match(TokenKind::True)) return ExprLiteral{true};
+    if(match(TokenKind::False)) return ExprLiteral{false};
+    if(match(TokenKind::Int)) return ExprLiteral{std::stoll(prev().lexeme)};
+    if(match(TokenKind::Real)) return ExprLiteral{std::stod(prev().lexeme)};
+    if(match(TokenKind::String)) return ExprLiteral{prev().lexeme};
+    if(match(TokenKind::Ident)){
+      std::string first = prev().lexeme;
+      if(match(TokenKind::Dot)){
+        std::string key = expect(TokenKind::Ident, "property").lexeme;
+        return ExprProp{first,key};
+      } else if(match(TokenKind::Colon)) {
+        std::string label = expect(TokenKind::Ident, "label").lexeme;
+        return ExprLabelIs{first,label};
+      } else {
+        return ExprIdent{first};
+      }
+    }
+    error("Unexpected token in expression");
+  }
+
+  void collect_vars(const Expr& e, std::unordered_set<std::string>& out){
+    std::visit([&](auto&& node){
+      using T=std::decay_t<decltype(node)>;
+      if constexpr(std::is_same_v<T,ExprIdent>){ out.insert(node.name); }
+      else if constexpr(std::is_same_v<T,ExprProp>){ out.insert(node.var); }
+      else if constexpr(std::is_same_v<T,ExprLabelIs>){ out.insert(node.var); }
+      else if constexpr(std::is_same_v<T,ExprCmp>){ collect_vars(*node.lhs,out); collect_vars(*node.rhs,out); }
+      else if constexpr(std::is_same_v<T,ExprNot>){ collect_vars(*node.e,out); }
+      else if constexpr(std::is_same_v<T,ExprAnd>){ collect_vars(*node.lhs,out); collect_vars(*node.rhs,out); }
+      else if constexpr(std::is_same_v<T,ExprOr>){ collect_vars(*node.lhs,out); collect_vars(*node.rhs,out); }
+    }, e);
+  }
+};
+} // namespace
+
+Script parse_script(std::string_view input){
+  Parser p{lex(input)};
+  return p.parse_script();
+}
+
+} // namespace aurora::agql
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,9 @@ add_executable(aurora_tests
   test_storage_jsonl.cpp
   test_algo_bfs_dfs.cpp
   test_algo_dijkstra.cpp
+  test_agql_lexer.cpp
+  test_agql_parser.cpp
+  test_agql_exec_basic.cpp
 )
 
 target_link_libraries(aurora_tests PRIVATE aurora_core gtest_main)

--- a/tests/test_agql_exec_basic.cpp
+++ b/tests/test_agql_exec_basic.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include "aurora/agql/parser.hpp"
+#include "aurora/agql/exec.hpp"
+
+using namespace aurora;
+using namespace aurora::agql;
+
+TEST(AgqlExec, BasicQueries) {
+  Graph g;
+  // seed graph
+  auto add_user = [&](int id, const std::string& name, int age){
+    Properties p; p["id"] = Int(id); p["name"] = name; p["age"] = Int(age);
+    g.add_node({"User"}, p);
+  };
+  add_user(1,"Ada",37);
+  add_user(2,"Nicole",25);
+  add_user(3,"Q",30);
+  g.add_edge(1,2,{"FOLLOWS"}, {{"w", Real(1.0)}});
+  g.add_edge(3,2,{"FOLLOWS"}, {{"w", Real(0.5)}});
+
+  Executor ex(g);
+  // Create edge via ids
+  auto res = ex.run(parse_script("CREATE (a:User {id:1})-[:FOLLOWS]->(b:User {id:3});"));
+  EXPECT_EQ(res.edges_created,1u);
+  EXPECT_EQ(res.nodes_created,0u);
+
+  auto r1 = ex.run(parse_script("MATCH (u:User {name:\"Q\"}) RETURN u, u.name;"));
+  ASSERT_EQ(r1.rows.size(),1u);
+  EXPECT_TRUE(std::holds_alternative<NodeId>(r1.rows[0].columns[0].second));
+  EXPECT_EQ(std::get<std::string>(r1.rows[0].columns[1].second), "Q");
+
+  auto r2 = ex.run(parse_script("MATCH (u:User)-[:FOLLOWS]->(v:User) WHERE v.name = \"Nicole\" RETURN u.name;"));
+  std::vector<std::string> names;
+  for(auto& row : r2.rows) names.push_back(std::get<std::string>(row.columns[0].second));
+  std::sort(names.begin(), names.end());
+  ASSERT_EQ(names.size(),2u);
+  EXPECT_EQ(names[0],"Ada");
+  EXPECT_EQ(names[1],"Q");
+
+  auto r3 = ex.run(parse_script("MATCH (u:User) WHERE u.age >= 18 RETURN u.name;"));
+  EXPECT_EQ(r3.rows.size(),3u);
+
+  auto r4 = ex.run(parse_script("MATCH (u) WHERE u:User RETURN u;"));
+  EXPECT_EQ(r4.rows.size(),3u);
+
+  // type mismatch comparison -> false
+  auto r5 = ex.run(parse_script("MATCH (u:User) WHERE u.name = 5 RETURN u;"));
+  EXPECT_EQ(r5.rows.size(),0u);
+}
+

--- a/tests/test_agql_lexer.cpp
+++ b/tests/test_agql_lexer.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include "aurora/agql/lexer.hpp"
+
+using namespace aurora::agql;
+
+TEST(AgqlLexer, TokensAndEscapes) {
+  auto toks = lex("CREATE MATCH \"str\" 123 1.5 -> != <= >=");
+  EXPECT_EQ(toks[0].kind, TokenKind::Create);
+  EXPECT_EQ(toks[1].kind, TokenKind::Match);
+  EXPECT_EQ(toks[2].kind, TokenKind::String);
+  EXPECT_EQ(toks[3].kind, TokenKind::Int);
+  EXPECT_EQ(toks[4].kind, TokenKind::Real);
+  EXPECT_EQ(toks[5].kind, TokenKind::Arrow);
+  EXPECT_EQ(toks[6].kind, TokenKind::NotEqual);
+  EXPECT_EQ(toks[7].kind, TokenKind::LessEq);
+  EXPECT_EQ(toks[8].kind, TokenKind::GreaterEq);
+}
+
+TEST(AgqlLexer, CommentSkip) {
+  auto toks = lex("MATCH -- hi\nRETURN");
+  EXPECT_EQ(toks[0].kind, TokenKind::Match);
+  EXPECT_EQ(toks[1].kind, TokenKind::Return);
+}
+
+TEST(AgqlLexer, UnterminatedString) {
+  EXPECT_THROW(lex("\"oops"), LexError);
+}
+
+TEST(AgqlLexer, BadEscape) {
+  EXPECT_THROW(lex("\"\\x\""), LexError);
+}
+

--- a/tests/test_agql_parser.cpp
+++ b/tests/test_agql_parser.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+
+#include "aurora/agql/parser.hpp"
+
+using namespace aurora::agql;
+
+TEST(AgqlParser, ParseCreateNode) {
+  auto script = parse_script("CREATE (u:User {name:\"Ada\", age:37});");
+  ASSERT_EQ(script.stmts.size(),1);
+  auto* cn = std::get_if<StmtCreateNode>(&script.stmts[0]);
+  ASSERT_NE(cn,nullptr);
+  EXPECT_EQ(*cn->node.label, "User");
+  ASSERT_TRUE(cn->node.props);
+  EXPECT_EQ(cn->node.props->items.size(),2u);
+}
+
+TEST(AgqlParser, ParseCreateEdge) {
+  auto script = parse_script("CREATE (a:User {id:1, name:\"Ada\"})-[:FOLLOWS {w:1.0}]->(b:User {id:2, name:\"Q\"});");
+  auto* ce = std::get_if<StmtCreateEdge>(&script.stmts[0]);
+  ASSERT_NE(ce,nullptr);
+  EXPECT_EQ(*ce->rel.label, "FOLLOWS");
+  ASSERT_TRUE(ce->rel.props);
+  EXPECT_EQ(ce->rel.props->items.size(),1u);
+  EXPECT_TRUE(ce->left.props.has_value());
+  EXPECT_TRUE(ce->right.props.has_value());
+}
+
+TEST(AgqlParser, ParseMatchNode) {
+  auto script = parse_script("MATCH (u:User {name:\"Ada\"}) RETURN u, u.name;");
+  auto* m = std::get_if<StmtMatch>(&script.stmts[0]);
+  ASSERT_NE(m,nullptr);
+  ASSERT_FALSE(m->pattern.rel.has_value());
+  EXPECT_EQ(m->ret.size(),2u);
+}
+
+TEST(AgqlParser, ParseMatchWhereAlias) {
+  auto script = parse_script(
+    "MATCH (a:User {name:\"Ada\"})-[:FOLLOWS]->(b:User)\n"
+    "WHERE b.name = \"Q\" AND NOT (a:User AND b:User)\n"
+    "RETURN a AS src, b.name AS dstName;");
+  auto* m = std::get_if<StmtMatch>(&script.stmts[0]);
+  ASSERT_NE(m,nullptr);
+  ASSERT_TRUE(m->pattern.rel.has_value());
+  ASSERT_TRUE(m->where.has_value());
+  EXPECT_EQ(m->ret.size(),2u);
+  EXPECT_TRUE(m->ret[0].alias.has_value());
+}
+
+TEST(AgqlParser, NegativeTests) {
+  EXPECT_THROW(parse_script("CREATE (u:User {name:\"Ada\"};"), ParseError);
+  EXPECT_THROW(parse_script("MATCH (u) RETURN"), ParseError);
+  EXPECT_THROW(parse_script("CREATE (u); foo"), ParseError);
+  EXPECT_THROW(parse_script("MATCH (a) WHERE b.name = 1 RETURN a;"), ParseError);
+}
+


### PR DESCRIPTION
## Summary
- implement AGQL token definitions, AST, lexer, parser, and executor
- support CREATE, MATCH, WHERE, RETURN with simple patterns
- add unit tests for lexer, parser, and execution

## Testing
- `./install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5f17701dc832197f246609b101d06