### PR TITLE
Add durability and parallel features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ add_library(aurora_core STATIC
   src/algo/dijkstra.cpp
   src/algo/pagerank.cpp
   src/algo/components.cpp
+  src/algo/parallel.cpp
+  src/storage/wal.cpp
+  src/storage/snapshot.cpp
+  src/storage/recovery.cpp
+  src/storage/mempool.cpp
   src/agql/lexer.cpp
   src/agql/parser.cpp
   src/agql/exec.cpp
@@ -39,6 +44,8 @@ target_include_directories(aurora_core
 )
 
 target_compile_options(aurora_core PRIVATE -Wall -Wextra -Wpedantic)
+find_package(Threads REQUIRED)
+target_link_libraries(aurora_core PUBLIC Threads::Threads)
 
 install(FILES
   include/aurora/algo/bfs.hpp
@@ -63,6 +70,9 @@ install(FILES
 
 add_executable(aurora_bench bench/benchmark_queries.cpp)
 target_link_libraries(aurora_bench PRIVATE aurora_core)
+
+add_executable(aurora_scaling bench/benchmark_scaling.cpp)
+target_link_libraries(aurora_scaling PRIVATE aurora_core)
 
 if(AURORA_BUILD_TESTS)
   enable_testing()

--- a/bench/benchmark_scaling.cpp
+++ b/bench/benchmark_scaling.cpp
@@ -1,0 +1,25 @@
+#include <chrono>
+#include <iostream>
+
+#include "aurora/core/graph.hpp"
+#include "aurora/algo/bfs.hpp"
+#include "aurora/algo/parallel.hpp"
+
+int main() {
+  using namespace aurora;
+  Graph g;
+  const std::size_t N = 1000;
+  for (std::size_t i = 0; i < N; ++i) g.add_node();
+  for (std::size_t i = 1; i < N; ++i) g.add_edge(i, i + 1);
+  auto start = std::chrono::high_resolution_clock::now();
+  bfs(g, 1);
+  auto mid = std::chrono::high_resolution_clock::now();
+  algo::parallel_bfs(g, 1, 4);
+  auto end = std::chrono::high_resolution_clock::now();
+  std::cout << "seq bfs: "
+            << std::chrono::duration<double>(mid - start).count()
+            << "s, par bfs: "
+            << std::chrono::duration<double>(end - mid).count() << "s\n";
+  return 0;
+}
+

--- a/include/aurora/algo/parallel.hpp
+++ b/include/aurora/algo/parallel.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "aurora/algo/bfs.hpp"
+#include "aurora/algo/pagerank.hpp"
+
+namespace aurora::algo {
+
+BfsResult parallel_bfs(const Graph& g, NodeId source, std::size_t num_threads);
+PageRankResult parallel_pagerank(const Graph& g,
+                                 double damping,
+                                 std::size_t max_iter,
+                                 double tol,
+                                 std::size_t num_threads);
+
+} // namespace aurora::algo
+

--- a/include/aurora/core/graph.hpp
+++ b/include/aurora/core/graph.hpp
@@ -10,6 +10,9 @@
 namespace aurora {
 
 class Storage; // forward declaration
+namespace storage {
+class Snapshot;
+}
 
 class Graph {
 public:
@@ -49,6 +52,7 @@ private:
   EdgeId next_edge_id_ = 1;
 
   friend class Storage;
+  friend class storage::Snapshot;
 };
 
 } // namespace aurora

--- a/include/aurora/storage/mempool.hpp
+++ b/include/aurora/storage/mempool.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+
+namespace aurora::storage {
+
+template <typename T, std::size_t BlockSize = 1024>
+class Pool {
+public:
+  T* allocate() {
+    if (blocks_.empty() || blocks_.back()->used == BlockSize) {
+      blocks_.push_back(std::make_unique<Block>());
+    }
+    Block* blk = blocks_.back().get();
+    return &blk->items[blk->used++];
+  }
+
+  void deallocate(T*) { /* no-op */ }
+
+  std::size_t block_count() const { return blocks_.size(); }
+
+private:
+  struct Block {
+    std::array<T, BlockSize> items;
+    std::size_t used = 0;
+  };
+
+  std::vector<std::unique_ptr<Block>> blocks_;
+};
+
+} // namespace aurora::storage
+

--- a/include/aurora/storage/recovery.hpp
+++ b/include/aurora/storage/recovery.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora::storage {
+
+class Recovery {
+public:
+  static void restore(Graph& g,
+                      const std::string& snapshot_path,
+                      const std::string& wal_path);
+};
+
+} // namespace aurora::storage
+

--- a/include/aurora/storage/snapshot.hpp
+++ b/include/aurora/storage/snapshot.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora::storage {
+
+class Snapshot {
+public:
+  static void write(const Graph& g, const std::string& path);
+  static void read(Graph& g, const std::string& path);
+};
+
+} // namespace aurora::storage
+

--- a/include/aurora/storage/wal.hpp
+++ b/include/aurora/storage/wal.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace aurora::storage {
+
+class Wal {
+public:
+  explicit Wal(const std::string& path);
+
+  void append(const std::string& entry);
+  void flush();
+  void rotate();
+
+  const std::string& path() const { return path_; }
+
+private:
+  void open();
+
+  std::ofstream out_;
+  std::string base_path_;
+  std::string path_;
+  size_t index_ = 0;
+};
+
+} // namespace aurora::storage
+

--- a/src/algo/parallel.cpp
+++ b/src/algo/parallel.cpp
@@ -1,0 +1,113 @@
+#include "aurora/algo/parallel.hpp"
+
+#include <thread>
+#include <mutex>
+#include <vector>
+#include <cmath>
+
+namespace aurora::algo {
+
+BfsResult parallel_bfs(const Graph& g, NodeId source, std::size_t num_threads) {
+  BfsResult res;
+  if (!g.has_node(source) || num_threads == 0) return res;
+  std::vector<NodeId> frontier{source};
+  res.distance[source] = 0;
+  res.parent[source] = source;
+  std::unordered_set<NodeId> visited{source};
+  std::mutex mtx;
+
+  while (!frontier.empty()) {
+    std::vector<NodeId> next;
+    std::size_t n = frontier.size();
+    std::size_t chunk = (n + num_threads - 1) / num_threads;
+    std::vector<std::vector<NodeId>> local_next(num_threads);
+    std::vector<std::thread> threads;
+    for (std::size_t t = 0; t < num_threads; ++t) {
+      std::size_t start = t * chunk;
+      if (start >= n) break;
+      std::size_t end = std::min(start + chunk, n);
+      threads.emplace_back([&, start, end, t] {
+        for (std::size_t i = start; i < end; ++i) {
+          NodeId u = frontier[i];
+          std::size_t d = res.distance[u];
+          for (NodeId v : g.neighbors(u)) {
+            std::unique_lock lock(mtx);
+            if (visited.insert(v).second) {
+              res.distance[v] = d + 1;
+              res.parent[v] = u;
+              local_next[t].push_back(v);
+            }
+          }
+        }
+      });
+    }
+    for (auto& th : threads) th.join();
+    for (auto& vec : local_next) next.insert(next.end(), vec.begin(), vec.end());
+    frontier.swap(next);
+  }
+  return res;
+}
+
+PageRankResult parallel_pagerank(const Graph& g, double damping,
+                                 std::size_t max_iter, double tol,
+                                 std::size_t num_threads) {
+  PageRankResult res;
+  std::vector<NodeId> nodes;
+  nodes.reserve(g.node_count());
+  for (NodeId id = 1; id <= g.node_count(); ++id) {
+    if (g.has_node(id)) nodes.push_back(id);
+  }
+  std::size_t n = nodes.size();
+  if (n == 0 || num_threads == 0) return res;
+
+  std::unordered_map<NodeId, double> score;
+  double init = 1.0 / static_cast<double>(n);
+  for (NodeId id : nodes) score[id] = init;
+  std::unordered_map<NodeId, double> next;
+
+  for (std::size_t it = 0; it < max_iter; ++it) {
+    next.clear();
+    double dangling_sum = 0.0;
+    for (NodeId id : nodes) {
+      if (g.out_edges(id).empty()) dangling_sum += score[id];
+    }
+    std::vector<std::thread> threads;
+    std::size_t chunk = (n + num_threads - 1) / num_threads;
+    std::mutex mtx;
+    for (std::size_t t = 0; t < num_threads; ++t) {
+      std::size_t start = t * chunk;
+      if (start >= n) break;
+      std::size_t end = std::min(start + chunk, n);
+      threads.emplace_back([&, start, end] {
+        for (std::size_t i = start; i < end; ++i) {
+          NodeId id = nodes[i];
+          double s = dangling_sum / static_cast<double>(n);
+          for (EdgeId eid : g.in_edges(id)) {
+            const Edge* e = g.get_edge(eid);
+            NodeId src = e->src;
+            auto out = g.out_edges(src);
+            double denom = out.empty() ? static_cast<double>(n)
+                                       : static_cast<double>(out.size());
+            s += score[src] / denom;
+          }
+          double val = (1.0 - damping) / static_cast<double>(n) + damping * s;
+          std::unique_lock lock(mtx);
+          next[id] = val;
+        }
+      });
+    }
+    for (auto& th : threads) th.join();
+    double diff = 0.0;
+    for (NodeId id : nodes) {
+      diff += std::abs(next[id] - score[id]);
+      score[id] = next[id];
+    }
+    if (diff < tol) break;
+  }
+
+  res.scores = std::move(score);
+  return res;
+}
+
+} // namespace aurora::algo
+

--- a/src/storage/mempool.cpp
+++ b/src/storage/mempool.cpp
@@ -1,0 +1,4 @@
+#include "aurora/storage/mempool.hpp"
+
+// header-only template implementation
+

--- a/src/storage/recovery.cpp
+++ b/src/storage/recovery.cpp
@@ -1,0 +1,48 @@
+#include "aurora/storage/recovery.hpp"
+
+#include <fstream>
+#include <json.hpp>
+
+#include "aurora/common/value.hpp"
+#include "aurora/storage/snapshot.hpp"
+
+namespace aurora::storage {
+
+using nlohmann::json;
+
+void Recovery::restore(Graph& g, const std::string& snapshot_path,
+                       const std::string& wal_path) {
+  if (!snapshot_path.empty()) {
+    std::ifstream s(snapshot_path);
+    if (s.good()) {
+      s.close();
+      Snapshot::read(g, snapshot_path);
+    }
+  }
+  std::ifstream in(wal_path);
+  if (!in) return;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.empty()) continue;
+    json j = json::parse(line);
+    std::string op = j.at("op").get<std::string>();
+    if (op == "create_node") {
+      std::vector<std::string> labels;
+      if (j.contains("labels")) labels = j["labels"].get<std::vector<std::string>>();
+      Properties props;
+      if (j.contains("props")) from_json(j["props"], props);
+      g.add_node(labels, props);
+    } else if (op == "create_edge") {
+      NodeId src = j.at("src").get<NodeId>();
+      NodeId dst = j.at("dst").get<NodeId>();
+      std::vector<std::string> labels;
+      if (j.contains("labels")) labels = j["labels"].get<std::vector<std::string>>();
+      Properties props;
+      if (j.contains("props")) from_json(j["props"], props);
+      g.add_edge(src, dst, labels, props);
+    }
+  }
+}
+
+} // namespace aurora::storage
+

--- a/src/storage/snapshot.cpp
+++ b/src/storage/snapshot.cpp
@@ -1,0 +1,89 @@
+#include "aurora/storage/snapshot.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <json.hpp>
+
+#include "aurora/common/value.hpp"
+
+namespace aurora::storage {
+
+using nlohmann::json;
+
+static std::string tmp_path(const std::string& path) { return path + ".tmp"; }
+
+void Snapshot::write(const Graph& g, const std::string& path) {
+  json j;
+  j["timestamp"] = static_cast<std::uint64_t>(
+      std::chrono::system_clock::now().time_since_epoch().count());
+  j["nodes"] = json::array();
+  for (const auto& [id, node] : g.nodes_) {
+    json n;
+    n["id"] = node.id;
+    if (!node.labels.empty()) n["labels"] = node.labels;
+    if (!node.props.empty()) {
+      json pj;
+      to_json(pj, node.props);
+      n["props"] = std::move(pj);
+    }
+    j["nodes"].push_back(std::move(n));
+  }
+  j["edges"] = json::array();
+  for (const auto& [id, edge] : g.edges_) {
+    json e;
+    e["id"] = edge.id;
+    e["src"] = edge.src;
+    e["dst"] = edge.dst;
+    if (!edge.labels.empty()) e["labels"] = edge.labels;
+    if (!edge.props.empty()) {
+      json pj;
+      to_json(pj, edge.props);
+      e["props"] = std::move(pj);
+    }
+    j["edges"].push_back(std::move(e));
+  }
+  std::string tpath = tmp_path(path);
+  std::ofstream out(tpath, std::ios::binary);
+  out << j.dump();
+  out.close();
+  std::filesystem::rename(tpath, path);
+}
+
+void Snapshot::read(Graph& g, const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) return;
+  json j;
+  in >> j;
+  g.clear();
+  NodeId max_node = 0;
+  EdgeId max_edge = 0;
+  for (const auto& n : j["nodes"]) {
+    Node node;
+    node.id = n.at("id").get<NodeId>();
+    if (n.contains("labels")) node.labels = n.at("labels").get<std::vector<std::string>>();
+    if (n.contains("props")) from_json(n.at("props"), node.props);
+    g.nodes_.emplace(node.id, node);
+    g.out_adj_[node.id];
+    g.in_adj_[node.id];
+    max_node = std::max(max_node, node.id);
+  }
+  for (const auto& e : j["edges"]) {
+    Edge edge;
+    edge.id = e.at("id").get<EdgeId>();
+    edge.src = e.at("src").get<NodeId>();
+    edge.dst = e.at("dst").get<NodeId>();
+    if (e.contains("labels")) edge.labels = e.at("labels").get<std::vector<std::string>>();
+    if (e.contains("props")) from_json(e.at("props"), edge.props);
+    if (!g.has_node(edge.src) || !g.has_node(edge.dst)) continue;
+    g.edges_.emplace(edge.id, edge);
+    g.out_adj_[edge.src].push_back(edge.id);
+    g.in_adj_[edge.dst].push_back(edge.id);
+    max_edge = std::max(max_edge, edge.id);
+  }
+  g.next_node_id_ = max_node + 1;
+  g.next_edge_id_ = max_edge + 1;
+}
+
+} // namespace aurora::storage
+

--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -1,0 +1,25 @@
+#include "aurora/storage/wal.hpp"
+
+#include <filesystem>
+
+namespace aurora::storage {
+
+Wal::Wal(const std::string& path) : base_path_(path) { open(); }
+
+void Wal::open() {
+  path_ = base_path_ + "." + std::to_string(index_);
+  out_.open(path_, std::ios::app);
+}
+
+void Wal::append(const std::string& entry) { out_ << entry << '\n'; }
+
+void Wal::flush() { out_.flush(); }
+
+void Wal::rotate() {
+  out_.close();
+  ++index_;
+  open();
+}
+
+} // namespace aurora::storage
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ add_executable(aurora_tests
   test_agql_exec_mutation.cpp
   test_index.cpp
   test_agql_match_index.cpp
+  test_wal.cpp
+  test_snapshot_recovery.cpp
+  test_mempool.cpp
+  test_parallel_algo.cpp
 )
 
 target_link_libraries(aurora_tests PRIVATE aurora_core gtest_main)

--- a/tests/test_mempool.cpp
+++ b/tests/test_mempool.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "aurora/storage/mempool.hpp"
+
+using namespace aurora::storage;
+
+TEST(MemPool, BlockAllocation) {
+  Pool<int, 4> pool;
+  std::vector<int*> ptrs;
+  for (int i = 0; i < 10; ++i) ptrs.push_back(pool.allocate());
+  EXPECT_GE(pool.block_count(), 3u);
+}
+
+TEST(MemPool, StressAlloc) {
+  Pool<int> pool;
+  for (int i = 0; i < 100000; ++i) pool.allocate();
+  EXPECT_GE(pool.block_count(), 100000 / 1024);
+}
+

--- a/tests/test_parallel_algo.cpp
+++ b/tests/test_parallel_algo.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include "aurora/algo/parallel.hpp"
+#include "aurora/algo/bfs.hpp"
+#include "aurora/algo/pagerank.hpp"
+#include "aurora/core/graph.hpp"
+
+using namespace aurora;
+
+TEST(ParallelAlgo, BFS) {
+  Graph g;
+  auto a = g.add_node();
+  auto b = g.add_node();
+  auto c = g.add_node();
+  g.add_edge(a, b);
+  g.add_edge(b, c);
+  g.add_edge(a, c);
+  auto seq = bfs(g, a);
+  auto par = algo::parallel_bfs(g, a, 2);
+  EXPECT_EQ(seq.distance, par.distance);
+}
+
+TEST(ParallelAlgo, PageRank) {
+  Graph g;
+  auto a = g.add_node();
+  auto b = g.add_node();
+  auto c = g.add_node();
+  g.add_edge(a, b);
+  g.add_edge(b, c);
+  g.add_edge(c, a);
+  auto seq = pagerank(g);
+  auto par = algo::parallel_pagerank(g, 0.85, 20, 1e-6, 2);
+  for (const auto& [id, s] : seq.scores) {
+    EXPECT_NEAR(s, par.scores[id], 1e-6);
+  }
+}
+

--- a/tests/test_snapshot_recovery.cpp
+++ b/tests/test_snapshot_recovery.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+#include <filesystem>
+#include <fstream>
+
+#include "aurora/core/graph.hpp"
+#include "aurora/storage/snapshot.hpp"
+#include "aurora/storage/recovery.hpp"
+#include "aurora/storage/wal.hpp"
+
+using namespace aurora;
+using namespace aurora::storage;
+
+TEST(SnapshotRecovery, Basic) {
+  Graph g;
+  auto a = g.add_node({"User"}, {{"name", Text("Ada")}});
+  auto b = g.add_node({"User"}, {{"name", Text("Bob")}});
+  g.add_edge(a, b);
+  Snapshot::write(g, "snap.bin");
+  Graph g2;
+  Recovery::restore(g2, "snap.bin", "");
+  EXPECT_TRUE(g2.has_node(a));
+  EXPECT_TRUE(g2.has_node(b));
+  EXPECT_EQ(g2.edge_count(), 1);
+  std::filesystem::remove("snap.bin");
+}
+
+TEST(SnapshotRecovery, ApplyWal) {
+  Graph g;
+  auto a = g.add_node();
+  Snapshot::write(g, "snap.bin");
+  Wal wal("rec_wal");
+  wal.append("{\"op\":\"create_node\",\"labels\":[\"User\"],\"props\":{\"name\":\"Eve\"}}");
+  wal.flush();
+  Graph g2;
+  Recovery::restore(g2, "snap.bin", "rec_wal.0");
+  EXPECT_EQ(g2.node_count(), 2);
+  std::filesystem::remove("snap.bin");
+  std::filesystem::remove("rec_wal.0");
+}
+

--- a/tests/test_wal.cpp
+++ b/tests/test_wal.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <filesystem>
+
+#include "aurora/storage/wal.hpp"
+
+using namespace aurora::storage;
+
+TEST(WalTest, AppendAndRotate) {
+  std::string base = "wal_test";
+  Wal wal(base);
+  wal.append("{\"op\":\"create_node\",\"id\":1}");
+  wal.flush();
+  std::ifstream in(base + ".0");
+  std::string line;
+  std::getline(in, line);
+  EXPECT_EQ(line, "{\"op\":\"create_node\",\"id\":1}");
+  wal.rotate();
+  wal.append("{\"op\":\"create_node\",\"id\":2}");
+  wal.flush();
+  std::ifstream in2(base + ".1");
+  std::getline(in2, line);
+  EXPECT_EQ(line, "{\"op\":\"create_node\",\"id\":2}");
+  std::filesystem::remove(base + ".0");
+  std::filesystem::remove(base + ".1");
+}
+


### PR DESCRIPTION
## Summary
- implement write-ahead logging and rotation
- add snapshot and recovery utilities for graph state
- introduce simple memory pool allocator
- provide parallel BFS and PageRank algorithms
- add tests and scaling benchmark

## Testing
- `cmake .. && make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b601e51b4c8321bc22bf230e97eb2d