### PR TITLE
Add initial Qt-based GUI for AuroraGraph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ add_executable(aurora_cli
 target_include_directories(aurora_cli PUBLIC include)
 target_link_libraries(aurora_cli PRIVATE aurora_core linenoise)
 
+add_subdirectory(gui)
+
 if(AURORA_BUILD_TESTS)
   enable_testing()
   add_subdirectory(tests)

--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -1,0 +1,20 @@
+# AuroraGraph GUI
+
+This GUI provides a minimal interface for viewing and querying graphs.
+
+## Building
+
+```
+cmake -S . -B build
+cmake --build build
+```
+
+## Usage
+
+* **File → Open**: import `nodes.jsonl` and `edges.jsonl` files.
+* **File → Save**: export the current graph to JSONL.
+* **Query Tab**: write AGQL queries and press the Run toolbar button (or `Ctrl+R`).
+* **Graph Tab**: shows a simple visualization of nodes and edges; use the Layout button to arrange nodes.
+* **Theme**: toggle dark/light using the toolbar button.
+
+Keyboard shortcuts: `Ctrl+O`, `Ctrl+S`, `Ctrl+R`, `Ctrl+L`.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.20)
+project(AuroraGraphGUI LANGUAGES CXX)
+
+find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+qt_add_resources(aurora_gui_rcc resources/aurora.qrc)
+
+add_executable(AuroraGraphGUI
+  ${aurora_gui_rcc}
+  ../src/gui/main.cpp
+  ../src/gui/app.cpp
+  ../src/gui/main_window.cpp
+  ../src/gui/graph_view.cpp
+  ../src/gui/node_item.cpp
+  ../src/gui/edge_item.cpp
+  ../src/gui/side_panel.cpp
+  ../src/gui/query_editor.cpp
+  ../src/gui/result_table.cpp
+  ../src/gui/status_bar.cpp
+  ../src/gui/dialogs.cpp
+  ../src/gui/agql_highlighter.cpp
+  ../src/gui/job.cpp
+  ../src/gui/job_runner.cpp
+)
+
+target_include_directories(AuroraGraphGUI PUBLIC
+  ${CMAKE_SOURCE_DIR}/gui/include
+  ${CMAKE_SOURCE_DIR}/include
+)
+
+target_link_libraries(AuroraGraphGUI PRIVATE Qt6::Widgets aurora_core)

--- a/gui/include/aurora/gui/agql_highlighter.hpp
+++ b/gui/include/aurora/gui/agql_highlighter.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+
+namespace aurora::gui {
+class AgqlHighlighter : public QSyntaxHighlighter {
+public:
+  explicit AgqlHighlighter(QTextDocument* parent = nullptr);
+protected:
+  void highlightBlock(const QString& text) override;
+private:
+  QTextCharFormat keywordFormat_;
+  QTextCharFormat numberFormat_;
+  QTextCharFormat stringFormat_;
+  QTextCharFormat commentFormat_;
+};
+}

--- a/gui/include/aurora/gui/app.hpp
+++ b/gui/include/aurora/gui/app.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <memory>
+namespace aurora::gui {
+class App {
+public:
+  static int run(int argc, char** argv);
+};
+}

--- a/gui/include/aurora/gui/dialogs.hpp
+++ b/gui/include/aurora/gui/dialogs.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <QString>
+class QWidget;
+
+namespace aurora::gui::dialogs {
+QString openFile(QWidget* parent, const QString& filter);
+QString saveFile(QWidget* parent, const QString& filter);
+}

--- a/gui/include/aurora/gui/edge_item.hpp
+++ b/gui/include/aurora/gui/edge_item.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QGraphicsLineItem>
+#include "aurora/core/edge.hpp"
+
+namespace aurora::gui {
+class NodeItem;
+class EdgeItem : public QGraphicsLineItem {
+public:
+  EdgeItem(const aurora::Edge& e, NodeItem* src, NodeItem* dst, QGraphicsItem* parent = nullptr);
+  aurora::EdgeId id() const { return edge_.id; }
+  void updatePosition();
+private:
+  aurora::Edge edge_;
+  NodeItem* src_;
+  NodeItem* dst_;
+};
+} // namespace aurora::gui

--- a/gui/include/aurora/gui/graph_view.hpp
+++ b/gui/include/aurora/gui/graph_view.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QGraphicsView>
+#include <unordered_map>
+
+#include "aurora/core/graph.hpp"
+
+namespace aurora::gui {
+class NodeItem;
+class EdgeItem;
+
+class GraphView : public QGraphicsView {
+public:
+  explicit GraphView(QWidget* parent = nullptr);
+  void setGraph(aurora::Graph* g);
+  void rebuildScene();
+  void applyLayout();
+private:
+  QGraphicsScene scene_;
+  aurora::Graph* g_ = nullptr;
+  std::unordered_map<aurora::NodeId, NodeItem*> nodes_;
+  std::unordered_map<aurora::EdgeId, EdgeItem*> edges_;
+};
+} // namespace aurora::gui

--- a/gui/include/aurora/gui/job.hpp
+++ b/gui/include/aurora/gui/job.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include <QRunnable>
+#include <functional>
+#include <QString>
+
+namespace aurora::gui {
+class Job : public QRunnable {
+public:
+  std::function<void()> fn;
+  std::function<void()> on_done;
+  std::function<void(const QString&)> on_error;
+  void run() override;
+};
+}

--- a/gui/include/aurora/gui/job_runner.hpp
+++ b/gui/include/aurora/gui/job_runner.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <QObject>
+#include <QThreadPool>
+#include <memory>
+
+#include "job.hpp"
+
+namespace aurora::gui {
+class JobRunner : public QObject {
+public:
+  explicit JobRunner(QObject* parent = nullptr);
+  void post(std::unique_ptr<Job> job);
+  void cancelAll();
+private:
+  QThreadPool pool_;
+};
+}

--- a/gui/include/aurora/gui/main_window.hpp
+++ b/gui/include/aurora/gui/main_window.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QMainWindow>
+#include <memory>
+#include <unordered_map>
+
+#include "aurora/core/graph.hpp"
+#include "aurora/agql/exec.hpp"
+
+#include "status_bar.hpp"
+
+namespace aurora::gui {
+class GraphView;
+class QueryEditor;
+class ResultTable;
+class JobRunner;
+
+class MainWindow : public QMainWindow {
+public:
+  MainWindow();
+  ~MainWindow() override;
+  void openJsonl();
+  void saveJsonl();
+  void runQuery();
+  void applyLayout();
+  void toggleTheme();
+private:
+  void setupUi();
+  void connectSignals();
+  void applyTheme(bool dark);
+  void refreshStats();
+
+  aurora::Graph graph_;
+  std::unique_ptr<aurora::agql::Executor> exec_;
+  GraphView* graphView_{};
+  QueryEditor* queryEditor_{};
+  ResultTable* resultTable_{};
+  JobRunner* jobRunner_{};
+  StatusBar* status_{};
+  bool dark_ = true;
+};
+}

--- a/gui/include/aurora/gui/node_item.hpp
+++ b/gui/include/aurora/gui/node_item.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QGraphicsEllipseItem>
+#include "aurora/core/node.hpp"
+
+namespace aurora::gui {
+class NodeItem : public QGraphicsEllipseItem {
+public:
+  explicit NodeItem(const aurora::Node& n, QGraphicsItem* parent = nullptr);
+  aurora::NodeId id() const { return node_.id; }
+private:
+  aurora::Node node_;
+};
+} // namespace aurora::gui

--- a/gui/include/aurora/gui/query_editor.hpp
+++ b/gui/include/aurora/gui/query_editor.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <QPlainTextEdit>
+
+namespace aurora::gui {
+class AgqlHighlighter;
+class QueryEditor : public QPlainTextEdit {
+public:
+  explicit QueryEditor(QWidget* parent = nullptr);
+private:
+  AgqlHighlighter* highlighter_;
+};
+}

--- a/gui/include/aurora/gui/result_table.hpp
+++ b/gui/include/aurora/gui/result_table.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <QTableView>
+
+namespace aurora { namespace agql { struct QueryResult; }}
+
+namespace aurora::gui {
+class ResultTable : public QTableView {
+public:
+  explicit ResultTable(QWidget* parent = nullptr);
+  void setResult(const aurora::agql::QueryResult& res);
+};
+}

--- a/gui/include/aurora/gui/side_panel.hpp
+++ b/gui/include/aurora/gui/side_panel.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <QDockWidget>
+
+namespace aurora::gui {
+class SidePanel : public QDockWidget {
+public:
+  explicit SidePanel(const QString& title, QWidget* parent = nullptr);
+};
+}

--- a/gui/include/aurora/gui/status_bar.hpp
+++ b/gui/include/aurora/gui/status_bar.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <QStatusBar>
+#include <QLabel>
+
+namespace aurora::gui {
+class StatusBar : public QStatusBar {
+public:
+  explicit StatusBar(QWidget* parent = nullptr);
+  void setStats(size_t nodes, size_t edges);
+private:
+  QLabel* stats_;
+};
+}

--- a/gui/resources/aurora.qrc
+++ b/gui/resources/aurora.qrc
@@ -1,0 +1,13 @@
+<RCC>
+  <qresource prefix="/">
+    <file>qdark.qss</file>
+    <file>icons/open.svg</file>
+    <file>icons/save.svg</file>
+    <file>icons/play.svg</file>
+    <file>icons/stop.svg</file>
+    <file>icons/zoom_in.svg</file>
+    <file>icons/zoom_out.svg</file>
+    <file>icons/layout.svg</file>
+    <file>icons/theme.svg</file>
+  </qresource>
+</RCC>

--- a/gui/resources/icons/layout.svg
+++ b/gui/resources/icons/layout.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="5" cy="5" r="3" fill="#ffffff"/>
+  <circle cx="19" cy="5" r="3" fill="#ffffff"/>
+  <circle cx="5" cy="19" r="3" fill="#ffffff"/>
+  <circle cx="19" cy="19" r="3" fill="#ffffff"/>
+  <path stroke="#ffffff" stroke-width="2" d="M8 5h8M5 8v8M19 8v8M8 19h8"/>
+</svg>

--- a/gui/resources/icons/open.svg
+++ b/gui/resources/icons/open.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#ffffff" d="M3 4h6l2 3h10v13H3z"/>
+</svg>

--- a/gui/resources/icons/play.svg
+++ b/gui/resources/icons/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#ffffff" d="M8 5v14l11-7z"/>
+</svg>

--- a/gui/resources/icons/save.svg
+++ b/gui/resources/icons/save.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#ffffff" d="M5 3h14v18H5z"/>
+  <path fill="#2b2b2b" d="M7 5h10v4H7z"/>
+</svg>

--- a/gui/resources/icons/stop.svg
+++ b/gui/resources/icons/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="6" y="6" width="12" height="12" fill="#ffffff"/>
+</svg>

--- a/gui/resources/icons/theme.svg
+++ b/gui/resources/icons/theme.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#ffffff" d="M12 2a10 10 0 100 20 8 8 0 010-20z"/>
+</svg>

--- a/gui/resources/icons/zoom_in.svg
+++ b/gui/resources/icons/zoom_in.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="10" cy="10" r="7" stroke="#ffffff" fill="none" stroke-width="2"/>
+  <line x1="21" y1="21" x2="15" y2="15" stroke="#ffffff" stroke-width="2"/>
+  <line x1="10" y1="7" x2="10" y2="13" stroke="#ffffff" stroke-width="2"/>
+  <line x1="7" y1="10" x2="13" y2="10" stroke="#ffffff" stroke-width="2"/>
+</svg>

--- a/gui/resources/icons/zoom_out.svg
+++ b/gui/resources/icons/zoom_out.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="10" cy="10" r="7" stroke="#ffffff" fill="none" stroke-width="2"/>
+  <line x1="21" y1="21" x2="15" y2="15" stroke="#ffffff" stroke-width="2"/>
+  <line x1="7" y1="10" x2="13" y2="10" stroke="#ffffff" stroke-width="2"/>
+</svg>

--- a/gui/resources/qdark.qss
+++ b/gui/resources/qdark.qss
@@ -1,0 +1,5 @@
+QWidget { background-color: #2b2b2b; color: #ffffff; }
+QMenuBar::item:selected { background: #3c3f41; }
+QToolBar { background: #2b2b2b; }
+QPlainTextEdit { background: #1e1e1e; color: #dddddd; }
+QTableView { background: #1e1e1e; color: #dddddd; gridline-color: #3c3f41; }

--- a/include/aurora/core/graph.hpp
+++ b/include/aurora/core/graph.hpp
@@ -39,6 +39,11 @@ public:
   size_t node_count() const noexcept { return nodes_.size(); }
   size_t edge_count() const noexcept { return edges_.size(); }
 
+  // Expose const accessors for iteration without modifying the graph.
+  // These are mainly intended for visualization/inspection purposes.
+  const std::unordered_map<NodeId, Node>& nodes() const noexcept { return nodes_; }
+  const std::unordered_map<EdgeId, Edge>& edges() const noexcept { return edges_; }
+
   void clear();
 
 private:

--- a/src/gui/agql_highlighter.cpp
+++ b/src/gui/agql_highlighter.cpp
@@ -1,0 +1,41 @@
+#include "aurora/gui/agql_highlighter.hpp"
+#include <QRegularExpression>
+
+namespace aurora::gui {
+AgqlHighlighter::AgqlHighlighter(QTextDocument* parent)
+    : QSyntaxHighlighter(parent) {
+  keywordFormat_.setForeground(Qt::cyan);
+  keywordFormat_.setFontWeight(QFont::Bold);
+  numberFormat_.setForeground(Qt::magenta);
+  stringFormat_.setForeground(Qt::green);
+  commentFormat_.setForeground(Qt::gray);
+}
+
+void AgqlHighlighter::highlightBlock(const QString& text) {
+  static const QStringList keywords = {"MATCH", "RETURN", "WHERE", "CREATE", "DELETE", "SET"};
+  for (const QString& kw : keywords) {
+    QRegularExpression rx("\\b" + kw + "\\b", QRegularExpression::CaseInsensitiveOption);
+    auto it = rx.globalMatch(text);
+    while (it.hasNext()) {
+      auto m = it.next();
+      setFormat(m.capturedStart(), m.capturedLength(), keywordFormat_);
+    }
+  }
+  QRegularExpression numRe("\\b[0-9]+(\\.[0-9]+)?\\b");
+  auto it2 = numRe.globalMatch(text);
+  while (it2.hasNext()) {
+    auto m = it2.next();
+    setFormat(m.capturedStart(), m.capturedLength(), numberFormat_);
+  }
+  QRegularExpression strRe("\"[^\"]*\"|'[^']*'");
+  auto it3 = strRe.globalMatch(text);
+  while (it3.hasNext()) {
+    auto m = it3.next();
+    setFormat(m.capturedStart(), m.capturedLength(), stringFormat_);
+  }
+  int idx = text.indexOf('#');
+  if (idx >= 0) {
+    setFormat(idx, text.length() - idx, commentFormat_);
+  }
+}
+} // namespace aurora::gui

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1,0 +1,12 @@
+#include "aurora/gui/app.hpp"
+#include <QApplication>
+#include "aurora/gui/main_window.hpp"
+
+namespace aurora::gui {
+int App::run(int argc, char** argv) {
+  QApplication app(argc, argv);
+  MainWindow w;
+  w.show();
+  return app.exec();
+}
+}

--- a/src/gui/dialogs.cpp
+++ b/src/gui/dialogs.cpp
@@ -1,0 +1,12 @@
+#include "aurora/gui/dialogs.hpp"
+#include <QFileDialog>
+#include <QObject>
+
+namespace aurora::gui::dialogs {
+QString openFile(QWidget* parent, const QString& filter) {
+  return QFileDialog::getOpenFileName(parent, QObject::tr("Open"), QString(), filter);
+}
+QString saveFile(QWidget* parent, const QString& filter) {
+  return QFileDialog::getSaveFileName(parent, QObject::tr("Save"), QString(), filter);
+}
+}

--- a/src/gui/edge_item.cpp
+++ b/src/gui/edge_item.cpp
@@ -1,0 +1,13 @@
+#include "aurora/gui/edge_item.hpp"
+#include "aurora/gui/node_item.hpp"
+
+namespace aurora::gui {
+EdgeItem::EdgeItem(const aurora::Edge& e, NodeItem* src, NodeItem* dst, QGraphicsItem* parent)
+    : QGraphicsLineItem(parent), edge_(e), src_(src), dst_(dst) {}
+
+void EdgeItem::updatePosition() {
+  if (src_ && dst_) {
+    setLine(QLineF(src_->pos(), dst_->pos()));
+  }
+}
+}

--- a/src/gui/graph_view.cpp
+++ b/src/gui/graph_view.cpp
@@ -1,0 +1,62 @@
+#include "aurora/gui/graph_view.hpp"
+#include "aurora/gui/node_item.hpp"
+#include "aurora/gui/edge_item.hpp"
+
+#include <QWheelEvent>
+#include <cmath>
+
+using namespace aurora;
+
+namespace aurora::gui {
+
+GraphView::GraphView(QWidget* parent) : QGraphicsView(parent) {
+  setScene(&scene_);
+  setRenderHint(QPainter::Antialiasing);
+}
+
+void GraphView::setGraph(aurora::Graph* g) {
+  g_ = g;
+  rebuildScene();
+}
+
+void GraphView::rebuildScene() {
+  scene_.clear();
+  nodes_.clear();
+  edges_.clear();
+  if (!g_) return;
+  int idx = 0;
+  for (const auto& [id, node] : g_->nodes()) {
+    auto item = new NodeItem(node);
+    item->setRect(-10, -10, 20, 20);
+    item->setFlag(QGraphicsItem::ItemIsMovable);
+    item->setFlag(QGraphicsItem::ItemIsSelectable);
+    item->setPos(idx * 30, 0);
+    scene_.addItem(item);
+    nodes_[id] = item;
+    ++idx;
+  }
+  for (const auto& [id, edge] : g_->edges()) {
+    auto s = nodes_[edge.src];
+    auto d = nodes_[edge.dst];
+    if (!s || !d) continue;
+    auto item = new EdgeItem(edge, s, d);
+    item->updatePosition();
+    scene_.addItem(item);
+    edges_[id] = item;
+  }
+}
+
+void GraphView::applyLayout() {
+  int n = nodes_.size();
+  if (n == 0) return;
+  double radius = 100.0;
+  int i = 0;
+  for (auto& [id, item] : nodes_) {
+    double angle = 2 * M_PI * i / n;
+    item->setPos(radius * std::cos(angle), radius * std::sin(angle));
+    ++i;
+  }
+  for (auto& [id, e] : edges_) e->updatePosition();
+}
+
+} // namespace aurora::gui

--- a/src/gui/job.cpp
+++ b/src/gui/job.cpp
@@ -1,0 +1,12 @@
+#include "aurora/gui/job.hpp"
+
+namespace aurora::gui {
+void Job::run() {
+  try {
+    if (fn) fn();
+    if (on_done) on_done();
+  } catch (const std::exception& e) {
+    if (on_error) on_error(QString::fromUtf8(e.what()));
+  }
+}
+}

--- a/src/gui/job_runner.cpp
+++ b/src/gui/job_runner.cpp
@@ -1,0 +1,15 @@
+#include "aurora/gui/job_runner.hpp"
+
+namespace aurora::gui {
+JobRunner::JobRunner(QObject* parent) : QObject(parent) {
+  pool_.setMaxThreadCount(QThread::idealThreadCount());
+}
+
+void JobRunner::post(std::unique_ptr<Job> job) {
+  pool_.start(job.release());
+}
+
+void JobRunner::cancelAll() {
+  pool_.clear();
+}
+}

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -1,0 +1,5 @@
+#include "aurora/gui/app.hpp"
+
+int main(int argc, char** argv) {
+  return aurora::gui::App::run(argc, argv);
+}

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1,0 +1,164 @@
+#include "aurora/gui/main_window.hpp"
+
+#include <QAction>
+#include <QApplication>
+#include <QFile>
+#include <QFileDialog>
+#include <QHBoxLayout>
+#include <QMenuBar>
+#include <QMessageBox>
+#include <QSplitter>
+#include <QStandardItemModel>
+#include <QTabWidget>
+#include <QToolBar>
+
+#include "aurora/core/storage.hpp"
+#include "aurora/gui/graph_view.hpp"
+#include "aurora/gui/query_editor.hpp"
+#include "aurora/gui/result_table.hpp"
+#include "aurora/gui/status_bar.hpp"
+#include "aurora/gui/dialogs.hpp"
+#include "aurora/gui/job_runner.hpp"
+#include "aurora/agql/parser.hpp"
+
+using namespace aurora;
+
+namespace aurora::gui {
+
+MainWindow::MainWindow() {
+  setupUi();
+  connectSignals();
+  exec_ = std::make_unique<agql::Executor>(graph_);
+  jobRunner_ = new JobRunner(this);
+  applyTheme(true);
+  refreshStats();
+}
+
+MainWindow::~MainWindow() = default;
+
+void MainWindow::setupUi() {
+  setWindowTitle("AuroraGraphGUI");
+
+  auto openAct = new QAction(QIcon(":/icons/open.svg"), tr("Open"), this);
+  openAct->setShortcut(QKeySequence::Open);
+  openAct->setObjectName("open");
+  auto saveAct = new QAction(QIcon(":/icons/save.svg"), tr("Save"), this);
+  saveAct->setShortcut(QKeySequence::Save);
+  saveAct->setObjectName("save");
+  auto runAct = new QAction(QIcon(":/icons/play.svg"), tr("Run"), this);
+  runAct->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_R));
+  runAct->setObjectName("run");
+  auto layoutAct = new QAction(QIcon(":/icons/layout.svg"), tr("Layout"), this);
+  layoutAct->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_L));
+  layoutAct->setObjectName("layout");
+  auto themeAct = new QAction(QIcon(":/icons/theme.svg"), tr("Theme"), this);
+  themeAct->setObjectName("theme");
+
+  QToolBar* tb = addToolBar(tr("Main"));
+  tb->addAction(openAct);
+  tb->addAction(saveAct);
+  tb->addAction(runAct);
+  tb->addAction(layoutAct);
+  tb->addAction(themeAct);
+
+  QMenu* fileMenu = menuBar()->addMenu(tr("&File"));
+  fileMenu->addAction(openAct);
+  fileMenu->addAction(saveAct);
+  QMenu* queryMenu = menuBar()->addMenu(tr("&Query"));
+  queryMenu->addAction(runAct);
+  QMenu* viewMenu = menuBar()->addMenu(tr("&View"));
+  viewMenu->addAction(layoutAct);
+  viewMenu->addAction(themeAct);
+
+  auto tabs = new QTabWidget(this);
+  setCentralWidget(tabs);
+
+  graphView_ = new GraphView;
+  graphView_->setGraph(&graph_);
+  tabs->addTab(graphView_, tr("Graph"));
+
+  auto queryTab = new QWidget;
+  auto splitter = new QSplitter(Qt::Horizontal, queryTab);
+  queryEditor_ = new QueryEditor;
+  resultTable_ = new ResultTable;
+  splitter->addWidget(queryEditor_);
+  splitter->addWidget(resultTable_);
+  splitter->setStretchFactor(0, 3);
+  splitter->setStretchFactor(1, 2);
+  auto layout = new QHBoxLayout(queryTab);
+  layout->setContentsMargins(0,0,0,0);
+  layout->addWidget(splitter);
+  tabs->addTab(queryTab, tr("Query"));
+
+  status_ = new StatusBar(this);
+  setStatusBar(status_);
+}
+
+void MainWindow::connectSignals() {
+  auto openAct = findChild<QAction*>("open");
+  auto saveAct = findChild<QAction*>("save");
+  auto runAct = findChild<QAction*>("run");
+  auto layoutAct = findChild<QAction*>("layout");
+  auto themeAct = findChild<QAction*>("theme");
+  connect(openAct, &QAction::triggered, this, &MainWindow::openJsonl);
+  connect(saveAct, &QAction::triggered, this, &MainWindow::saveJsonl);
+  connect(runAct, &QAction::triggered, this, &MainWindow::runQuery);
+  connect(layoutAct, &QAction::triggered, this, &MainWindow::applyLayout);
+  connect(themeAct, &QAction::triggered, this, &MainWindow::toggleTheme);
+}
+
+void MainWindow::applyTheme(bool dark) {
+  dark_ = dark;
+  if (dark) {
+    QFile f(":/qdark.qss");
+    if (f.open(QIODevice::ReadOnly)) {
+      qApp->setStyleSheet(QString::fromUtf8(f.readAll()));
+    }
+  } else {
+    qApp->setStyleSheet({});
+  }
+}
+
+void MainWindow::toggleTheme() { applyTheme(!dark_); }
+
+void MainWindow::openJsonl() {
+  QString nodes = dialogs::openFile(this, tr("Nodes (*.jsonl)"));
+  if (nodes.isEmpty()) return;
+  QString edges = dialogs::openFile(this, tr("Edges (*.jsonl)"));
+  if (edges.isEmpty()) return;
+  Storage::import_jsonl(graph_, nodes.toStdString(), edges.toStdString());
+  graphView_->rebuildScene();
+  refreshStats();
+}
+
+void MainWindow::saveJsonl() {
+  QString nodes = dialogs::saveFile(this, tr("Nodes (*.jsonl)"));
+  if (nodes.isEmpty()) return;
+  QString edges = dialogs::saveFile(this, tr("Edges (*.jsonl)"));
+  if (edges.isEmpty()) return;
+  Storage::export_jsonl(graph_, nodes.toStdString(), edges.toStdString());
+}
+
+void MainWindow::runQuery() {
+  QString text = queryEditor_->textCursor().selectedText();
+  if (text.isEmpty()) text = queryEditor_->toPlainText();
+  try {
+    auto script = agql::parse_script(text.toStdString());
+    auto res = exec_->run(script);
+    resultTable_->setResult(res);
+    graphView_->rebuildScene();
+    refreshStats();
+  } catch (const std::exception& e) {
+    QMessageBox::critical(this, tr("AGQL error"), e.what());
+  }
+}
+
+void MainWindow::applyLayout() {
+  graphView_->applyLayout();
+}
+
+void MainWindow::refreshStats() {
+  status_->setStats(graph_.node_count(), graph_.edge_count());
+}
+
+} // namespace aurora::gui

--- a/src/gui/node_item.cpp
+++ b/src/gui/node_item.cpp
@@ -1,0 +1,6 @@
+#include "aurora/gui/node_item.hpp"
+
+namespace aurora::gui {
+NodeItem::NodeItem(const aurora::Node& n, QGraphicsItem* parent)
+    : QGraphicsEllipseItem(parent), node_(n) {}
+}

--- a/src/gui/query_editor.cpp
+++ b/src/gui/query_editor.cpp
@@ -1,0 +1,9 @@
+#include "aurora/gui/query_editor.hpp"
+#include "aurora/gui/agql_highlighter.hpp"
+
+namespace aurora::gui {
+QueryEditor::QueryEditor(QWidget* parent) : QPlainTextEdit(parent) {
+  highlighter_ = new AgqlHighlighter(document());
+  setTabStopDistance(4 * fontMetrics().horizontalAdvance(' '));
+}
+}

--- a/src/gui/result_table.cpp
+++ b/src/gui/result_table.cpp
@@ -1,0 +1,38 @@
+#include "aurora/gui/result_table.hpp"
+#include <QStandardItemModel>
+#include "aurora/agql/exec.hpp"
+
+using namespace aurora;
+
+namespace aurora::gui {
+ResultTable::ResultTable(QWidget* parent) : QTableView(parent) {
+  setModel(new QStandardItemModel(this));
+}
+
+void ResultTable::setResult(const aurora::agql::QueryResult& res) {
+  auto* m = qobject_cast<QStandardItemModel*>(model());
+  m->clear();
+  if (res.rows.empty()) return;
+  const auto& cols = res.rows.front().columns;
+  for (int c = 0; c < static_cast<int>(cols.size()); ++c) {
+    m->setHorizontalHeaderItem(c, new QStandardItem(QString::fromStdString(cols[c].first)));
+  }
+  int r = 0;
+  for (const auto& row : res.rows) {
+    m->setRowCount(r + 1);
+    for (int c = 0; c < static_cast<int>(row.columns.size()); ++c) {
+      const auto& val = row.columns[c].second;
+      QString text;
+      if (std::holds_alternative<std::monostate>(val)) text = "null";
+      else if (auto p = std::get_if<int64_t>(&val)) text = QString::number(*p);
+      else if (auto p = std::get_if<double>(&val)) text = QString::number(*p);
+      else if (auto p = std::get_if<bool>(&val)) text = *p ? "true" : "false";
+      else if (auto p = std::get_if<std::string>(&val)) text = QString::fromStdString(*p);
+      else if (auto p = std::get_if<NodeId>(&val)) text = QString("#%1").arg(*p);
+      m->setItem(r, c, new QStandardItem(text));
+    }
+    ++r;
+  }
+  resizeColumnsToContents();
+}
+} // namespace aurora::gui

--- a/src/gui/side_panel.cpp
+++ b/src/gui/side_panel.cpp
@@ -1,0 +1,6 @@
+#include "aurora/gui/side_panel.hpp"
+
+namespace aurora::gui {
+SidePanel::SidePanel(const QString& title, QWidget* parent)
+    : QDockWidget(title, parent) {}
+}

--- a/src/gui/status_bar.cpp
+++ b/src/gui/status_bar.cpp
@@ -1,0 +1,12 @@
+#include "aurora/gui/status_bar.hpp"
+
+namespace aurora::gui {
+StatusBar::StatusBar(QWidget* parent) : QStatusBar(parent) {
+  stats_ = new QLabel(this);
+  addPermanentWidget(stats_);
+}
+
+void StatusBar::setStats(size_t nodes, size_t edges) {
+  stats_->setText(QString("Nodes: %1 Edges: %2").arg(nodes).arg(edges));
+}
+}


### PR DESCRIPTION
## Summary
- introduce Qt6-based AuroraGraphGUI application with graph view, query editor, and result table
- extend core graph API with const accessors for nodes and edges to support visualization
- document GUI build and usage instructions

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68b60b948b5483218b79b2cdd96c8dea