### PR TITLE
Make GUI optional when Qt6 is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ add_executable(aurora_cli
 target_include_directories(aurora_cli PUBLIC include)
 target_link_libraries(aurora_cli PRIVATE aurora_core linenoise)
 
-add_subdirectory(gui)
+# Build GUI only if Qt6 is available
+find_package(Qt6 COMPONENTS Widgets QUIET)
+if(Qt6_FOUND)
+  add_subdirectory(gui)
+else()
+  message(STATUS "Qt6 not found; skipping GUI build")
+endif()
 
 if(AURORA_BUILD_TESTS)
   enable_testing()

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ algorithms and query processing.
 ```
 
 This script configures and builds the project in `build/` and runs the unit tests.
+If Qt6 is not available, the GUI target is skipped.
 
 ## JSONL Format
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,16 @@
+# Code Review Report
+
+## Executive Summary
+The build previously failed when Qt6 was not installed because the GUI target was
+unconditionally added. The CMake logic now checks for Qt6 and skips the GUI when
+missing, allowing headless builds and tests to succeed.
+
+## Findings
+- **Build robustness:** Added optional GUI detection in `CMakeLists.txt` to avoid
+  hard failure on systems without Qt6.
+- **Documentation:** Updated `README.md` to note that the GUI is skipped when Qt6
+  is absent.
+
+## Testing
+- `./install.sh` builds the project and runs the unit tests. All tests pass when
+  Qt6 is unavailable.

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
 project(AuroraGraphGUI LANGUAGES CXX)
 
-find_package(Qt6 COMPONENTS Widgets REQUIRED)
+
+# Qt6 is discovered in the parent project, so the Qt6::Widgets target should
+# already be available.
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary
- Skip GUI build when Qt6 is unavailable
- Document optional GUI build behavior
- Add code review report

## Testing
- `./install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6118b100083218bb1895730b43919