### PR TITLE
Fix size type conversion warning in GraphView

### DIFF
--- a/src/gui/graph_view.cpp
+++ b/src/gui/graph_view.cpp
@@ -4,6 +4,7 @@
 
 #include <QWheelEvent>
 #include <cmath>
+#include <cstddef>
 
 using namespace aurora;
 
@@ -47,7 +48,7 @@ void GraphView::rebuildScene() {
 }
 
 void GraphView::applyLayout() {
-  int n = nodes_.size();
+  std::size_t n = nodes_.size();
   if (n == 0) return;
   double radius = 100.0;
   int i = 0;


### PR DESCRIPTION
## Summary
- Use `std::size_t` for node count in GraphView layout
- Include `<cstddef>` for `std::size_t`

## Testing
- `g++ -std=c++17 -fPIC -Wall -Wextra -Igui/include -Isrc -Iinclude $(pkg-config --cflags Qt5Widgets) -fsyntax-only src/gui/graph_view.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68b7196b45688321b4b5d78e0cacbbea