### PR TITLE
Fix variable shadowing in ResultTable

### DIFF
--- a/src/gui/result_table.cpp
+++ b/src/gui/result_table.cpp
@@ -22,11 +22,11 @@ void ResultTable::setResult(const aurora::agql::QueryResult& res) {
       const auto& val = row.columns[c].second;
       QString text;
       if (std::holds_alternative<std::monostate>(val)) text = "null";
-      else if (auto p = std::get_if<int64_t>(&val)) text = QString::number(*p);
-      else if (auto p = std::get_if<double>(&val)) text = QString::number(*p);
-      else if (auto p = std::get_if<bool>(&val)) text = *p ? "true" : "false";
-      else if (auto p = std::get_if<std::string>(&val)) text = QString::fromStdString(*p);
-      else if (auto p = std::get_if<aurora::NodeId>(&val)) text = QString("#%1").arg(*p);
+      else if (auto pInt = std::get_if<int64_t>(&val)) text = QString::number(*pInt);
+      else if (auto pDouble = std::get_if<double>(&val)) text = QString::number(*pDouble);
+      else if (auto pBool = std::get_if<bool>(&val)) text = *pBool ? "true" : "false";
+      else if (auto pString = std::get_if<std::string>(&val)) text = QString::fromStdString(*pString);
+      else if (auto pNodeId = std::get_if<aurora::NodeId>(&val)) text = QString("#%1").arg(*pNodeId);
       m->setItem(r, c, new QStandardItem(text));
     }
     ++r;


### PR DESCRIPTION
## Summary
- Rename temporary result value pointers in `ResultTable::setResult` to distinct names

## Testing
- `g++ -std=c++20 -Wall -Wextra -Wshadow -fsyntax-only src/gui/result_table.cpp -I gui/include -I include $(pkg-config --cflags Qt6Widgets)`

------
https://chatgpt.com/codex/tasks/task_e_68b71c548e548321bbc2dab96fe6c3c7